### PR TITLE
Fix NumbaDeprecationWarning: specify nopython mode when using @jit

### DIFF
--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -1,6 +1,6 @@
 import logging
 import numpy as np
-from numba import jit
+from numba import njit
 from .. import links
 from ..models import Model
 from ..utils import MaskedModel, shapley_coefficients, make_masks, delta_minimization_order
@@ -175,7 +175,7 @@ class Exact(Explainer):
             "clustering": getattr(self.masker, "clustering", None)
         }
 
-@jit
+@njit
 def _compute_grey_code_row_values(row_values, mask, inds, outputs, shapley_coeff, extended_delta_indexes, noop_code):
     set_size = 0
     M = len(inds)
@@ -201,7 +201,7 @@ def _compute_grey_code_row_values(row_values, mask, inds, outputs, shapley_coeff
             else:
                 row_values[j] -= out * off_coeff
 
-@jit
+@njit
 def _compute_grey_code_row_values_st(row_values, mask, inds, outputs, shapley_coeff, extended_delta_indexes, noop_code):
     set_size = 0
     M = len(inds)

--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -1,6 +1,6 @@
 import logging
 import numpy as np
-from numba import njit
+from numba import jit
 from .. import links
 from ..models import Model
 from ..utils import MaskedModel, shapley_coefficients, make_masks, delta_minimization_order
@@ -175,7 +175,7 @@ class Exact(Explainer):
             "clustering": getattr(self.masker, "clustering", None)
         }
 
-@njit
+@jit(nopython=False)
 def _compute_grey_code_row_values(row_values, mask, inds, outputs, shapley_coeff, extended_delta_indexes, noop_code):
     set_size = 0
     M = len(inds)
@@ -201,7 +201,7 @@ def _compute_grey_code_row_values(row_values, mask, inds, outputs, shapley_coeff
             else:
                 row_values[j] -= out * off_coeff
 
-@njit
+@jit(nopython=False)
 def _compute_grey_code_row_values_st(row_values, mask, inds, outputs, shapley_coeff, extended_delta_indexes, noop_code):
     set_size = 0
     M = len(inds)

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -4,7 +4,7 @@ from ..utils._exceptions import DimensionError
 from ._masker import Masker
 from .._serializable import Serializer, Deserializer
 import heapq
-from numba import jit
+from numba import njit
 try:
     import torch
 except ImportError as e:
@@ -171,7 +171,7 @@ class Image(Masker):
             kwargs["shape"] = s.load("shape")
         return kwargs
 
-@jit
+@njit
 def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q):
     """ This partitions an image into a herarchical clustering based on axis-aligned splits.
     """

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -4,7 +4,7 @@ from ..utils._exceptions import DimensionError
 from ._masker import Masker
 from .._serializable import Serializer, Deserializer
 import heapq
-from numba import njit
+from numba import jit
 try:
     import torch
 except ImportError as e:
@@ -171,7 +171,7 @@ class Image(Masker):
             kwargs["shape"] = s.load("shape")
         return kwargs
 
-@njit
+@jit(nopython=False)
 def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q):
     """ This partitions an image into a herarchical clustering based on axis-aligned splits.
     """

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd
 import numpy as np
-from numba import jit
+from numba import njit
 from .. import utils
 from ..utils import safe_isinstance, MaskedModel
 from ..utils._exceptions import DimensionError, InvalidClusteringError
@@ -182,7 +182,7 @@ class Tabular(Masker):
             kwargs["clustering"] = s.load("clustering")
         return kwargs
 
-@jit
+@njit
 def _single_delta_mask(dind, masked_inputs, last_mask, data, x, noop_code):
     if dind == noop_code:
         pass
@@ -193,7 +193,7 @@ def _single_delta_mask(dind, masked_inputs, last_mask, data, x, noop_code):
         masked_inputs[:, dind] = x[dind]
         last_mask[dind] = True
 
-@jit
+@njit
 def _delta_masking(masks, x, curr_delta_inds, varying_rows_out,
                    masked_inputs_tmp, last_mask, data, variants, masked_inputs_out, noop_code):
     """ Implements the special (high speed) delta masking API that only flips the positions we need to.

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -1,7 +1,7 @@
 import logging
 import pandas as pd
 import numpy as np
-from numba import njit
+from numba import jit
 from .. import utils
 from ..utils import safe_isinstance, MaskedModel
 from ..utils._exceptions import DimensionError, InvalidClusteringError
@@ -182,7 +182,7 @@ class Tabular(Masker):
             kwargs["clustering"] = s.load("clustering")
         return kwargs
 
-@njit
+@jit(nopython=False)
 def _single_delta_mask(dind, masked_inputs, last_mask, data, x, noop_code):
     if dind == noop_code:
         pass
@@ -193,7 +193,7 @@ def _single_delta_mask(dind, masked_inputs, last_mask, data, x, noop_code):
         masked_inputs[:, dind] = x[dind]
         last_mask[dind] = True
 
-@njit
+@jit(nopython=False)
 def _delta_masking(masks, x, curr_delta_inds, varying_rows_out,
                    masked_inputs_tmp, last_mask, data, variants, masked_inputs_out, noop_code):
     """ Implements the special (high speed) delta masking API that only flips the positions we need to.

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy as sp
 from scipy.spatial.distance import pdist
-from numba import jit
+from numba import njit
 import sklearn
 import warnings
 from ._general import safe_isinstance
@@ -31,7 +31,7 @@ def partition_tree_shuffle(indexes, index_mask, partition_tree):
     M = len(index_mask)
     #switch = np.random.randn(M) < 0
     _pt_shuffle_rec(partition_tree.shape[0]-1, indexes, index_mask, partition_tree, M, 0)
-@jit
+@njit
 def _pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos):
     if i < 0:
         # see if we should include this index in the ordering
@@ -50,7 +50,7 @@ def _pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos):
         pos = _pt_shuffle_rec(left, indexes, index_mask, partition_tree, M, pos)
     return pos
 
-@jit
+@njit
 def delta_minimization_order(all_masks, max_swap_size=100, num_passes=2):
     order = np.arange(len(all_masks))
     for _ in range(num_passes):
@@ -59,13 +59,13 @@ def delta_minimization_order(all_masks, max_swap_size=100, num_passes=2):
                 if _reverse_window_score_gain(all_masks, order, i, length) > 0:
                     _reverse_window(order, i, length)
     return order
-@jit
+@njit
 def _reverse_window(order, start, length):
     for i in range(length // 2):
         tmp = order[start + i]
         order[start + i] = order[start + length - i - 1]
         order[start + length - i - 1] = tmp
-@jit
+@njit
 def _reverse_window_score_gain(masks, order, start, length):
     forward_score = _mask_delta_score(masks[order[start - 1]], masks[order[start]]) + \
                     _mask_delta_score(masks[order[start + length-1]], masks[order[start + length]])
@@ -73,7 +73,7 @@ def _reverse_window_score_gain(masks, order, start, length):
                     _mask_delta_score(masks[order[start]], masks[order[start + length]])
     
     return forward_score - reverse_score
-@jit
+@njit
 def _mask_delta_score(m1, m2):
     return (m1 ^ m2).sum()
 

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy as sp
 from scipy.spatial.distance import pdist
-from numba import njit
+from numba import jit
 import sklearn
 import warnings
 from ._general import safe_isinstance
@@ -31,7 +31,7 @@ def partition_tree_shuffle(indexes, index_mask, partition_tree):
     M = len(index_mask)
     #switch = np.random.randn(M) < 0
     _pt_shuffle_rec(partition_tree.shape[0]-1, indexes, index_mask, partition_tree, M, 0)
-@njit
+@jit(nopython=False)
 def _pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos):
     if i < 0:
         # see if we should include this index in the ordering
@@ -50,7 +50,7 @@ def _pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos):
         pos = _pt_shuffle_rec(left, indexes, index_mask, partition_tree, M, pos)
     return pos
 
-@njit
+@jit(nopython=False)
 def delta_minimization_order(all_masks, max_swap_size=100, num_passes=2):
     order = np.arange(len(all_masks))
     for _ in range(num_passes):
@@ -59,13 +59,13 @@ def delta_minimization_order(all_masks, max_swap_size=100, num_passes=2):
                 if _reverse_window_score_gain(all_masks, order, i, length) > 0:
                     _reverse_window(order, i, length)
     return order
-@njit
+@jit(nopython=False)
 def _reverse_window(order, start, length):
     for i in range(length // 2):
         tmp = order[start + i]
         order[start + i] = order[start + length - i - 1]
         order[start + length - i - 1] = tmp
-@njit
+@jit(nopython=False)
 def _reverse_window_score_gain(masks, order, start, length):
     forward_score = _mask_delta_score(masks[order[start - 1]], masks[order[start]]) + \
                     _mask_delta_score(masks[order[start + length-1]], masks[order[start + length]])
@@ -73,7 +73,7 @@ def _reverse_window_score_gain(masks, order, start, length):
                     _mask_delta_score(masks[order[start]], masks[order[start + length]])
     
     return forward_score - reverse_score
-@njit
+@jit(nopython=False)
 def _mask_delta_score(m1, m2):
     return (m1 ^ m2).sum()
 

--- a/shap/utils/_masked_model.py
+++ b/shap/utils/_masked_model.py
@@ -1,7 +1,7 @@
 import copy
 import numpy as np
 import scipy.sparse
-from numba import njit
+from numba import jit
 from .. import links
 
 
@@ -288,7 +288,7 @@ def _convert_delta_mask_to_full(masks, full_masks):
             full_masks[i,masks[masks_pos]] = ~full_masks[i,masks[masks_pos]]
         masks_pos += 1
 
-#@njit # TODO: figure out how to jit this function, or most of it
+#@jit(nopython=False) # TODO: figure out how to jit this function, or most of it
 def _build_delta_masked_inputs(masks, batch_positions, num_mask_samples, num_varying_rows, delta_indexes,
                                varying_rows, args, masker, variants, variants_column_sums):
     all_masked_inputs = [[] for a in args]
@@ -359,7 +359,7 @@ def _build_fixed_output(averaged_outs, last_outs, outputs, batch_positions, vary
     else:
         _build_fixed_multi_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, link, linearizing_weights)
 
-@njit # we can't use this when using a custom link function...
+@jit(nopython=False) # we can't use this when using a custom link function...
 def _build_fixed_single_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, link, linearizing_weights):
     # here we can assume that the outputs will always be the same size, and we need
     # to carry over evaluation outputs
@@ -381,7 +381,7 @@ def _build_fixed_single_output(averaged_outs, last_outs, outputs, batch_position
         else:
             averaged_outs[i] = averaged_outs[i-1]
 
-@njit
+@jit(nopython=False)
 def _build_fixed_multi_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, link, linearizing_weights):
     # here we can assume that the outputs will always be the same size, and we need
     # to carry over evaluation outputs
@@ -424,7 +424,7 @@ def make_masks(cluster_matrix):
 
     return mask_matrix
 
-@njit
+@jit(nopython=False)
 def _init_masks(cluster_matrix, M, indices_row_pos, indptr):
     pos = 0
     for i in range(2 * M - 1):
@@ -435,7 +435,7 @@ def _init_masks(cluster_matrix, M, indices_row_pos, indptr):
         indptr[i+1] = pos
         indices_row_pos[i] = indptr[i]
 
-@njit
+@jit(nopython=False)
 def _rec_fill_masks(cluster_matrix, indices_row_pos, indptr, indices, M, ind):
     pos = indices_row_pos[ind]
 

--- a/shap/utils/_masked_model.py
+++ b/shap/utils/_masked_model.py
@@ -1,7 +1,7 @@
 import copy
 import numpy as np
 import scipy.sparse
-from numba import jit
+from numba import njit
 from .. import links
 
 
@@ -288,7 +288,7 @@ def _convert_delta_mask_to_full(masks, full_masks):
             full_masks[i,masks[masks_pos]] = ~full_masks[i,masks[masks_pos]]
         masks_pos += 1
 
-#@jit # TODO: figure out how to jit this function, or most of it
+#@njit # TODO: figure out how to jit this function, or most of it
 def _build_delta_masked_inputs(masks, batch_positions, num_mask_samples, num_varying_rows, delta_indexes,
                                varying_rows, args, masker, variants, variants_column_sums):
     all_masked_inputs = [[] for a in args]
@@ -359,7 +359,7 @@ def _build_fixed_output(averaged_outs, last_outs, outputs, batch_positions, vary
     else:
         _build_fixed_multi_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, link, linearizing_weights)
 
-@jit # we can't use this when using a custom link function...
+@njit # we can't use this when using a custom link function...
 def _build_fixed_single_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, link, linearizing_weights):
     # here we can assume that the outputs will always be the same size, and we need
     # to carry over evaluation outputs
@@ -381,7 +381,7 @@ def _build_fixed_single_output(averaged_outs, last_outs, outputs, batch_position
         else:
             averaged_outs[i] = averaged_outs[i-1]
 
-@jit
+@njit
 def _build_fixed_multi_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, link, linearizing_weights):
     # here we can assume that the outputs will always be the same size, and we need
     # to carry over evaluation outputs
@@ -424,7 +424,7 @@ def make_masks(cluster_matrix):
 
     return mask_matrix
 
-@jit
+@njit
 def _init_masks(cluster_matrix, M, indices_row_pos, indptr):
     pos = 0
     for i in range(2 * M - 1):
@@ -435,7 +435,7 @@ def _init_masks(cluster_matrix, M, indices_row_pos, indptr):
         indptr[i+1] = pos
         indices_row_pos[i] = indptr[i]
 
-@jit
+@njit
 def _rec_fill_masks(cluster_matrix, indices_row_pos, indptr, indices, M, ind):
     pos = indices_row_pos[ind]
 


### PR DESCRIPTION
Fixes: https://github.com/slundberg/shap/issues/2909

This updates the Just-In-Time compiler decorators to explicitly avoid using "nopython" mode. Numba has recently been raising a DeprecationWarning as per:
https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit

This change replaces `@numba.jit` with `@numba.njit`, which is equivalent to `@numba.jit(nopython=True)`. This removes the deprecationwarning, but will explicitly cause an exception to be raised if the relevant functions cannot be jit-compiled without reverting to the slower "nopython" mode. So, might want to wait until the test suite is passing to ensure this change does not break anything.