### PR TITLE
Use legacy tensorflow optimizers to stay compatible to tf v1.

### DIFF
--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -102,7 +102,7 @@ def test_tf_keras_mnist_cnn(): # pylint: disable=too-many-locals
     model.add(Activation('softmax'))
 
     model.compile(loss=keras.losses.categorical_crossentropy,
-                  optimizer=keras.optimizers.Adadelta(),
+                  optimizer=keras.optimizers.legacy.Adadelta(),
                   metrics=['accuracy'])
 
     model.fit(x_train[:10, :], y_train[:10, :],
@@ -133,7 +133,7 @@ def test_tf_keras_linear():
 
     from tensorflow.keras.models import Model
     from tensorflow.keras.layers import Dense, Input
-    from tensorflow.keras.optimizers import SGD
+    from tensorflow.keras.optimizers.legacy import SGD
 
     tf.compat.v1.disable_eager_execution()
 

--- a/tests/explainers/test_gradient.py
+++ b/tests/explainers/test_gradient.py
@@ -69,7 +69,7 @@ def test_tf_keras_mnist_cnn():
     model.add(Activation('softmax'))
 
     model.compile(loss=tf.keras.losses.categorical_crossentropy,
-                  optimizer=tf.keras.optimizers.Adadelta(),
+                  optimizer=tf.keras.optimizers.legacy.Adadelta(),
                   metrics=['accuracy'])
 
     model.fit(


### PR DESCRIPTION
As mentioned in #15, this PR uses the tensorflow v1 compatible optimizers and fixes 3 tests with that change.