### PR TITLE
Update action versions & fix test that failed due to updated pandas version

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -36,4 +36,4 @@ jobs:
         run: |
           codecov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -269,7 +269,7 @@ def test_pyspark_regression_decision_tree():
     for regressor in regressors:
         model = regressor.fit(iris)
         explainer = shap.TreeExplainer(model)
-        X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names).drop('sepal length (cm)', 1)[:100] # pylint: disable=E1101
+        X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names).drop('sepal length (cm)', axis=1)[:100] # pylint: disable=E1101
 
         shap_values = explainer.shap_values(X)
         expected_values = explainer.expected_value


### PR DESCRIPTION
Hey, I updated the versions of the `checkout`, `setup_python` and `codecov-action` actions.

The previous versions were using very old nodejs versions which resulted in warnings after action runs.

Addtionally, I fixed a test that failed because it relied on an old signature of `df.drop()`.