### PR TITLE
Remove remaining usages of the boston dataset.

### DIFF
--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -4,6 +4,8 @@ import numpy as np
 import sklearn.datasets
 import shap
 
+from sklearn.utils import deprecated
+
 try:
     from urllib.request import urlretrieve
 except ImportError:
@@ -28,9 +30,9 @@ def imagenet50(display=False, resolution=224): # pylint: disable=unused-argument
     y = np.loadtxt(cache(prefix + "labels.csv"))
     return X, y
 
+@deprecated
 def boston(display=False): # pylint: disable=unused-argument
     """ Return the boston housing data in a nice package. """
-
     d = sklearn.datasets.load_boston()
     df = pd.DataFrame(data=d.data, columns=d.feature_names) # pylint: disable=E1101
     return df, d.target # pylint: disable=E1101

--- a/tests/maskers/test_custom.py
+++ b/tests/maskers/test_custom.py
@@ -9,7 +9,7 @@ def test_raw_function():
     """ Make sure passing a simple masking function works.
     """
 
-    X, _ = shap.datasets.boston()
+    X, _ = shap.datasets.california(n_points=500)
 
     def test(X):
         return np.sum(X, 1)

--- a/tests/maskers/test_tabular.py
+++ b/tests/maskers/test_tabular.py
@@ -10,7 +10,7 @@ def test_serialization_independent_masker_dataframe():
     """ Test the serialization of an Independent masker based on a data frame.
     """
 
-    X, _ = shap.datasets.boston()
+    X, _ = shap.datasets.california(n_points=500)
 
     # initialize independent masker
     original_independent_masker = shap.maskers.Independent(X)
@@ -37,7 +37,7 @@ def test_serialization_independent_masker_numpy():
     """
 
 
-    X, _ = shap.datasets.boston()
+    X, _ = shap.datasets.california(n_points=500)
     X = X.values
 
     # initialize independent masker
@@ -65,7 +65,7 @@ def test_serialization_partion_masker_dataframe():
     """ Test the serialization of a Partition masker based on a DataFrame.
     """
 
-    X, _ = shap.datasets.boston()
+    X, _ = shap.datasets.california(n_points=500)
 
     # initialize partition masker
     original_partition_masker = shap.maskers.Partition(X)
@@ -91,7 +91,7 @@ def test_serialization_partion_masker_numpy():
     """ Test the serialization of a Partition masker based on a numpy array.
     """
 
-    X, _ = shap.datasets.boston()
+    X, _ = shap.datasets.california(n_points=500)
     X = X.values
 
     # initialize partition masker

--- a/tests/plots/test_force.py
+++ b/tests/plots/test_force.py
@@ -10,7 +10,7 @@ def test_random_force_plot_mpl_with_data():
     RandomForestRegressor = pytest.importorskip('sklearn.ensemble').RandomForestRegressor
 
     # train model
-    X, y = shap.datasets.boston()
+    X, y = shap.datasets.california(n_points=500)
     model = RandomForestRegressor(n_estimators=100)
     model.fit(X, y)
 
@@ -28,7 +28,7 @@ def test_random_force_plot_mpl_text_rotation_with_data():
     RandomForestRegressor = pytest.importorskip('sklearn.ensemble').RandomForestRegressor
 
     # train model
-    X, y = shap.datasets.boston()
+    X, y = shap.datasets.california(n_points=500)
     model = RandomForestRegressor(n_estimators=100)
     model.fit(X, y)
 


### PR DESCRIPTION
There are a few remaining usages of the boston dataset in the tests that are not covered by #19.

As the california dataset is much bigger (20k samples) than the boston dataset (500 samples), I only used 500 samples of the california dataset to not increase test runtime too much (same as slundberg#2501).

Related to #4 and #8