### PR TITLE
Fix pytorch tests

### DIFF
--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -13,6 +13,21 @@ from shap import DeepExplainer
 
 # pylint: disable=import-outside-toplevel, no-name-in-module, import-error
 
+
+@pytest.fixture
+def legacy_boston_dataset():
+    """Returns boston house price dataset for use in test suite
+    
+    Nb. This is deprecated in sklearn. Including it here in order to reproduce the
+    original test suite, and get the tests passing. In future this could be replaced.
+    """
+    data_url = "http://lib.stat.cmu.edu/datasets/boston"
+    raw_df = pd.read_csv(data_url, sep="\\s+", skiprows=22, header=None)
+    data = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])
+    target = raw_df.values[1::2, 2]
+    return data, target
+
+
 def test_tf_eager():
     """ This is a basic eager example from keras.
     """
@@ -344,7 +359,7 @@ def test_pytorch_mnist_cnn():
     run_test(train_loader, test_loader, interim=False)
 
 
-def test_pytorch_custom_nested_models():
+def test_pytorch_custom_nested_models(legacy_boston_dataset):
     """Testing single outputs
     """
     torch = pytest.importorskip('torch')
@@ -352,9 +367,8 @@ def test_pytorch_custom_nested_models():
     from torch import nn
     from torch.nn import functional as F
     from torch.utils.data import TensorDataset, DataLoader
-    from sklearn.datasets import fetch_california_housing
 
-    X, y = fetch_california_housing(return_X_y=True)
+    X, y = legacy_boston_dataset
     num_features = X.shape[1]
     data = TensorDataset(torch.tensor(X).float(),
                          torch.tensor(y).float())
@@ -446,7 +460,7 @@ def test_pytorch_custom_nested_models():
     assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % (d / np.abs(diff).sum())
 
 
-def test_pytorch_single_output():
+def test_pytorch_single_output(legacy_boston_dataset):
     """Testing single outputs
     """
     torch = pytest.importorskip('torch')
@@ -454,9 +468,9 @@ def test_pytorch_single_output():
     from torch import nn
     from torch.nn import functional as F
     from torch.utils.data import TensorDataset, DataLoader
-    from sklearn.datasets import fetch_california_housing
+    # from sklearn.datasets import fetch_california_housing
 
-    X, y = fetch_california_housing(return_X_y=True)
+    X, y = legacy_boston_dataset
     num_features = X.shape[1]
     data = TensorDataset(torch.tensor(X).float(),
                          torch.tensor(y).float())
@@ -517,7 +531,7 @@ def test_pytorch_single_output():
     assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % (d / np.abs(diff).sum())
 
 
-def test_pytorch_multiple_inputs():
+def test_pytorch_multiple_inputs(legacy_boston_dataset):
     """ Check a multi-input scenario.
     """
     torch = pytest.importorskip('torch')
@@ -528,9 +542,9 @@ def test_pytorch_multiple_inputs():
         from torch import nn
         from torch.nn import functional as F
         from torch.utils.data import TensorDataset, DataLoader
-        from sklearn.datasets import fetch_california_housing
+
         torch.manual_seed(1)
-        X, y = fetch_california_housing(return_X_y=True)
+        X, y = legacy_boston_dataset
         num_features = X.shape[1]
         x1 = X[:, num_features // 2:]
         x2 = X[:, :num_features // 2]


### PR DESCRIPTION
This PR attempts to fix some failing unit tests, supporting #4.

```
tests/explainers/test_deep.py::test_pytorch_custom_nested_models
tests/explainers/test_deep.py::test_pytorch_single_output
tests/explainers/test_deep.py::test_pytorch_multiple_inputs
```

These tests were previously failing as the boston house price dataset is no longer availble in sklearn. I made a previous PR #19 to replace the Boston house dataset with the California dataset; however, this inadvertently broke the pytorch models and the tests still fail.

This PR reverts these tests to use the original data, using the sklearn's recommended way of loading the boston dataset from the original source. The above tests now pass locally.

In future the tests could be written with a different dataset, but I think a first priority is to get the test suite passing. Personally I don't see any issue with using the Boston dataset in the test suite, as it's not exposed to users at all.