### PR TITLE
chore: add environment related paths to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# slundberg/shap
 node_modules
 __pycache__
 shap.egg-info


### PR DESCRIPTION
I like to use `venv` for development, but I don't want to accidentally commit environment paths to the repo. I've added all environment-related paths from [https://github.com/github/gitignore/blob/main/Python.gitignore](https://github.com/github/gitignore/blob/main/Python.gitignore). 

Ideally, I'd like to add most of the suggestions from the above link and to organise the `.gitignore` into sections. At this stage, I don't want to accidentally ignore anything that we depend on.