### PR TITLE
chore: deprecate setup.py develop

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,10 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install packaging
-          python setup.py develop
-          pip install '.[test,plots]'
-          pip install tensorflow xgboost codecov torch torchvision pylint sentencepiece
+          pip install -e '.[test,plots]'
+          pip install tensorflow
       - name: Test with pytest
         run: |
           python -m pytest tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "packaging"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "packaging>20.9"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]


### PR DESCRIPTION
<s>Might be tangentially related to #30.</s>

Related to the Original PR slundberg#1802, though that proposed change was indirectly introduced in slundberg#2017 (merged) already.

Related to the PR slundberg#2655, though the PR here takes a slightly different approach. Still using `oldest-supported-numpy` instead of hardcoding the minimum numpy version, and move away from `setup_requires` (see below).

## Summary of changes

* In the `run_tests.yml` github workflow, use `pip install -e` instead of `python setup.py develop` to perform an editable installation (trigger the `build` process).
* By taking advantage of [PEP 517](https://peps.python.org/pep-0517/), we can directly specify build dependencies in `pyproject.toml` instead of the _hacky_ method of monkey patching `cmdclass`. `setup_requires=` in the `setup` call is also replaced by the build dependencies in `pyproject.toml`. This way, we can just do a top-level import numpy in `setup.py`.
* Also NUMPY_SETUP is deprecated since 1.13 as mentioned in the [attached StackOverflow question](https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py).
* I cleaned up the dependency installation in `run_tests.yml` slightly.