### PR TITLE
fix: change sampling to without replacement

### DIFF
--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -166,7 +166,12 @@ def encode_array_if_needed(arr, dtype=np.float64):
         return encoded_array
 
 def sample(X, nsamples=100, random_state=0):
-    if nsamples >= X.shape[0]:
+    if hasattr(X, "shape"):
+        over_count = nsamples >= X.shape[0]
+    else:
+        over_count = nsamples >= len(X)
+
+    if over_count:
         return X
     return sklearn.utils.shuffle(X, n_samples=nsamples, random_state=random_state)
 

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -168,8 +168,7 @@ def encode_array_if_needed(arr, dtype=np.float64):
 def sample(X, nsamples=100, random_state=0):
     if nsamples >= X.shape[0]:
         return X
-    else:
-        return sklearn.utils.resample(X, n_samples=nsamples, random_state=random_state)
+    return sklearn.utils.shuffle(X, n_samples=nsamples, random_state=random_state)
 
 def safe_isinstance(obj, class_path_str):
     """

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as ssp
+
+import shap
+
+
+@pytest.mark.parametrize(
+    "arr",
+    [
+        np.arange(100),
+        ["zz"] * 100,
+        pd.Series(range(100), name="test"),
+        pd.DataFrame(np.random.RandomState(0).randn(100, 2), columns=["a", "b"]),
+    ],
+)
+def test_sample_basic(arr):
+    """Tests the basic functionality of `sample()` on a variety of array-like objects."""
+    new_arr = shap.utils.sample(arr, 30, random_state=42)
+    assert len(new_arr) == 30
+
+
+def test_sample_basic_sparse():
+    """Tests the basic functionality of `sample()` on sparse objects."""
+    arr = ssp.csr_matrix((100, 3), dtype=np.int8)
+    new_arr = shap.utils.sample(arr, 30, random_state=42)
+    assert new_arr.shape[0] == 30
+
+
+def test_sample_no_op():
+    """Ensures that `sample()` is a no-op when numsamples is larger
+    than the size of X.
+    """
+    arr = np.arange(50)
+    new_arr = shap.utils.sample(arr, 100, random_state=42)
+
+    assert len(arr) == len(new_arr)
+
+
+def test_sample_sampling_without_replacement():
+    """Ensures that `sample()` is performing sampling without replacement.
+
+    See #36.
+    """
+    arr = np.arange(100)
+    new_arr = shap.utils.sample(arr, 99, random_state=0)
+
+    assert len(new_arr) == 99
+    assert len(np.unique(new_arr)) == 99
+
+
+def test_sample_can_be_zipped():
+    """Ensures that the sampling is done via indexing.
+
+    That is, sampling X and y separately would give the same result as sampling
+    concat(X, y), up to a random state. Our `datasets` module relies on
+    this behaviour.
+    """
+    arr1 = pd.Series(np.arange(100))
+    arr2 = pd.Series(np.repeat(np.arange(25), 4))
+    combined = pd.DataFrame(
+        {
+            "arr1": arr1,
+            "arr2": arr2,
+        }
+    )
+
+    new_arr1 = shap.utils.sample(arr1, 75, random_state=42)
+    new_arr2 = shap.utils.sample(arr2, 75, random_state=42)
+    new_combined = shap.utils.sample(combined, 75, random_state=42)
+
+    assert (new_arr1 == new_combined["arr1"]).all()
+    assert (new_arr2 == new_combined["arr2"]).all()


### PR DESCRIPTION
## Change 1: change sampling to without replacement

cf. slundberg#2738

---

`shap.utils.sample()` is primarily used in our `datasets` module and notebooks to generate a subset of the original data. E.g. [here](https://github.com/dsgibbons/shap/blob/e24b7019cda8889376b72353f6ad8bdcb1db0bcc/shap/datasets.py#L47).

However, the current implementation uses [`sklearn`'s resample](https://github.com/scikit-learn/scikit-learn/blob/72a604975102b2d93082385d7a5a7033886cc825/sklearn/utils/__init__.py#L476) which uses `replace=True` by default.

I think this is unexpected / unwanted behaviour. This PR changes to using sklearn `shuffle()` instead of `resample()` which is just the same as setting `replace=False`.


## Other minor changes

* add tests for `shap.utils.sample`
* use `len()` in cases where there is no `.shape` attribute, e.g. for ordinary python lists.