### PR TITLE
fix: deprecated should be called

### DIFF
--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -30,7 +30,7 @@ def imagenet50(display=False, resolution=224): # pylint: disable=unused-argument
     y = np.loadtxt(cache(prefix + "labels.csv"))
     return X, y
 
-@deprecated
+@deprecated()
 def boston(display=False): # pylint: disable=unused-argument
     """ Return the boston housing data in a nice package. """
     d = sklearn.datasets.load_boston()


### PR DESCRIPTION
The `deprecated` decorator introduced in #20 should be called, otherwise right now it causes an error.

![image](https://github.com/dsgibbons/shap/assets/30731072/b04a5b1d-c3ac-40e7-98a6-1d72cdfaa53f)
