### PR TITLE
Chore: Close matplotlib plots after use

### DIFF
--- a/tests/plots/conftest.py
+++ b/tests/plots/conftest.py
@@ -1,0 +1,10 @@
+"""Shared pytest fixtures"""
+
+import matplotlib.pyplot as plt
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def close_matplotlib_plots_after_tests():
+    plt.close("all")
+


### PR DESCRIPTION
Minor fix to address some warnings in the test suite: close all matploblib images after test excution, to free up memory