### PR TITLE
Use pytest-xdist for parallel test execution

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,9 +29,13 @@ jobs:
           pip install tensorflow
       - name: Test with pytest
         run: |
-          python -m pytest tests
-      - name: Run CodeCov
-        run: |
-          codecov
+          python -m pytest \
+          --cov-report=xml --cov-report=term-missing \
+          --durations=20 --junitxml=junit/pytest.xml
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: success() || failure()
+        with:
+          report_paths: '**/junit/*.xml'
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,7 +29,7 @@ jobs:
           pip install tensorflow
       - name: Test with pytest
         run: |
-          python -m pytest \
+          python -m pytest -n auto \
           --cov-report=xml --cov-report=term-missing \
           --durations=20 --junitxml=junit/pytest.xml
       - name: Publish Test Report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "oldest-supported-numpy", "packaging>20.9"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "--mpl --cov=shap --durations=20"
+addopts = "--mpl --cov=shap"
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,10 @@
 requires = ["setuptools", "wheel", "oldest-supported-numpy", "packaging>20.9"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+addopts = "--mpl --cov=shap --durations=20"
+testpaths = ["tests"]
+
 [tool.ruff]
 # Aim to get all pyflakes logical errors ("F") passing
 select = ["F"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-addopts = --mpl --cov=shap --cov-report=term-missing --durations=20
-testpaths =
-    tests

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ def run_setup(with_binary, test_xgboost, test_lightgbm, test_catboost, test_spar
         except Exception as e:
             raise Exception("Error building cuda module: " + repr(e)) from e
 
-    tests_require = ['pytest', 'pytest-mpl', 'pytest-cov']
+    tests_require = ['pytest', 'pytest-mpl', 'pytest-cov', 'pytest-xdist']
     if test_xgboost:
         tests_require += ['xgboost']
     if test_lightgbm:

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ def run_setup(with_binary, test_xgboost, test_lightgbm, test_catboost, test_spar
         except Exception as e:
             raise Exception("Error building cuda module: " + repr(e)) from e
 
-    tests_require = ['pytest', 'pytest-mpl', 'pytest-cov', 'codecov']
+    tests_require = ['pytest', 'pytest-mpl', 'pytest-cov']
     if test_xgboost:
         tests_require += ['xgboost']
     if test_lightgbm:


### PR DESCRIPTION
Parallelises tests with [pytest-xdist](https://pytest-xdist.readthedocs.io/en/latest/), which may lead to faster test execution.

Supports #42.

EDIT: It seems that this change speeds up test execution locally, but has no change on GitHub Actions - if anything, it seems to slow them down. This is probably because the workers have only 2 nodes, so parallelising the runners is not helpful.