### PR TITLE
Add JUnit test report summaries, and simplify test configuration

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,9 +29,13 @@ jobs:
           pip install tensorflow
       - name: Test with pytest
         run: |
-          python -m pytest tests
-      - name: Run CodeCov
-        run: |
-          codecov
+          python -m pytest \
+          --cov-report=xml --cov-report=term-missing \
+          --durations=20 --junitxml=junit/pytest.xml
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: success() || failure()
+        with:
+          report_paths: '**/junit/*.xml'
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "oldest-supported-numpy", "packaging>20.9"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "--mpl --cov=shap --durations=20"
+addopts = "--mpl --cov=shap"
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,10 @@
 requires = ["setuptools", "wheel", "oldest-supported-numpy", "packaging>20.9"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+addopts = "--mpl --cov=shap --durations=20"
+testpaths = ["tests"]
+
 [tool.ruff]
 # Aim to get all pyflakes logical errors ("F") passing
 select = ["F"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-addopts = --mpl --cov=shap --cov-report=term-missing --durations=20
-testpaths =
-    tests

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ def run_setup(with_binary, test_xgboost, test_lightgbm, test_catboost, test_spar
         except Exception as e:
             raise Exception("Error building cuda module: " + repr(e)) from e
 
-    tests_require = ['pytest', 'pytest-mpl', 'pytest-cov', 'codecov']
+    tests_require = ['pytest', 'pytest-mpl', 'pytest-cov']
     if test_xgboost:
         tests_require += ['xgboost']
     if test_lightgbm:


### PR DESCRIPTION
Adds a JUnit test result report, to make it easier to identify failed tests when reviewing PRs.

Supporting minor changes:

- Simplified config, using the existing `pyproject.toml` (which is now accepted by pytest) rather than a separate `pytest.ini` 
- Remove the `codecov` pacakge which is [deprecated](https://about.codecov.io/blog/message-regarding-the-pypi-package/) `codecov` and replaced by the codecov GitHub action
- Change the default pytest options to not display coverage results to terminal, so the output is cleaner & simpler when running tests locally. (But still keep same options for CI output)