### PR TITLE
fix: node_sample_weight array dtype with xgboost booster

### DIFF
--- a/shap/cext/_cext.cc
+++ b/shap/cext/_cext.cc
@@ -62,7 +62,7 @@ static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args)
     PyObject *children_right_obj;
     PyObject *node_sample_weight_obj;
     PyObject *values_obj;
-    
+
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
         args, "OOOO", &children_left_obj, &children_right_obj, &node_sample_weight_obj, &values_obj
@@ -131,7 +131,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     int model_output;
     PyObject *base_offset_obj;
     bool interactions;
-  
+
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
         args, "OOOOOOOiOOOOOiOOiib", &children_left_obj, &children_right_obj, &children_default_obj,
@@ -222,7 +222,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     // retrieve return value before python cleanup of objects
     tfloat ret_value = (double)values[0];
 
-    // clean up the created python objects 
+    // clean up the created python objects
     Py_XDECREF(children_left_array);
     Py_XDECREF(children_right_array);
     Py_XDECREF(children_default_array);
@@ -261,7 +261,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     PyObject *X_missing_obj;
     PyObject *y_obj;
     PyObject *out_pred_obj;
-  
+
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
         args, "OOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
@@ -339,7 +339,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
 
     dense_tree_predict(out_pred, trees, data, model_output);
 
-    // clean up the created python objects 
+    // clean up the created python objects
     Py_XDECREF(children_left_array);
     Py_XDECREF(children_right_array);
     Py_XDECREF(children_default_array);
@@ -371,7 +371,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     PyObject *node_sample_weight_obj;
     PyObject *X_obj;
     PyObject *X_missing_obj;
-  
+
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
         args, "OOOOOOiOOO", &children_left_obj, &children_right_obj, &children_default_obj,
@@ -433,14 +433,14 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
 
     dense_tree_update_weights(trees, data);
 
-    // clean up the created python objects 
+    // clean up the created python objects
     Py_XDECREF(children_left_array);
     Py_XDECREF(children_right_array);
     Py_XDECREF(children_default_array);
     Py_XDECREF(features_array);
     Py_XDECREF(thresholds_array);
     Py_XDECREF(values_array);
-    //PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
+    // PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
     Py_XDECREF(node_sample_weight_array);
     Py_XDECREF(X_array);
     Py_XDECREF(X_missing_array);
@@ -467,8 +467,8 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     PyObject *X_missing_obj;
     PyObject *y_obj;
     PyObject *out_pred_obj;
-    
-  
+
+
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
         args, "OOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
@@ -540,7 +540,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
 
     dense_tree_saabas(out_pred, trees, data);
 
-    // clean up the created python objects 
+    // clean up the created python objects
     Py_XDECREF(children_left_array);
     Py_XDECREF(children_right_array);
     Py_XDECREF(children_default_array);

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <iostream>
 #include <fstream>
-#include <stdio.h> 
+#include <stdio.h>
 #include <cmath>
 #include <ctime>
 #if defined(_WIN32) || defined(WIN32)
@@ -111,7 +111,7 @@ struct ExplanationDataset {
 
     ExplanationDataset() {}
     ExplanationDataset(tfloat *X, bool *X_missing, tfloat *y, tfloat *R, bool *R_missing, unsigned num_X,
-                       unsigned M, unsigned num_R) : 
+                       unsigned M, unsigned num_R) :
         X(X), X_missing(X_missing), y(y), R(R), R_missing(R_missing), num_X(num_X), M(M), num_R(num_R) {}
 
     void get_x_instance(ExplanationDataset &instance, const unsigned i) const {
@@ -180,12 +180,12 @@ inline tfloat *tree_predict(unsigned i, const TreeEnsemble &trees, const tfloat 
     while (true) {
         const unsigned pos = offset + node;
         const unsigned feature = trees.features[pos];
-        
+
         // we hit a leaf so return a pointer to the values
         if (trees.is_leaf(pos)) {
             return trees.values + pos * trees.num_outputs;
         }
-        
+
         // otherwise we are at an internal node and need to recurse
         if (x_missing[feature]) {
             node = trees.children_default[pos];
@@ -244,10 +244,10 @@ inline void tree_update_weights(unsigned i, TreeEnsemble &trees, const tfloat *x
 
         // Record that a sample passed through this node
         trees.node_sample_weights[pos] += 1.0;
-        
+
         // we hit a leaf so return a pointer to the values
         if (trees.children_left[pos] < 0) break;
-        
+
         // otherwise we are at an internal node and need to recurse
         if (x_missing[feature]) {
             node = trees.children_default[pos];
@@ -279,10 +279,10 @@ inline void tree_saabas(tfloat *out, const TreeEnsemble &tree, const Explanation
     unsigned curr_node = 0;
     unsigned next_node = 0;
     while (true) {
-        
+
         // we hit a leaf and are done
         if (tree.children_left[curr_node] < 0) return;
-        
+
         // otherwise we are at an internal node and need to recurse
         const unsigned feature = tree.features[curr_node];
         if (data.X_missing[feature]) {
@@ -516,9 +516,9 @@ inline int compute_expectations(TreeEnsemble &tree, int i = 0, int depth = 0) {
         }
         max_depth = std::max(depth_left, depth_right) + 1;
     }
-    
+
     if (depth == 0) tree.max_depth = max_depth;
-    
+
     return max_depth;
 }
 
@@ -555,7 +555,7 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
     //tfloat new_leaf_value[trees.num_outputs];
     tfloat *new_leaf_value = (tfloat *) alloca(sizeof(tfloat) * trees.num_outputs); // allocate on the stack
     unsigned row_offset = row * trees.max_nodes;
-  
+
     // we have hit a terminal leaf!!!
     if (trees.children_left[row_offset + i] < 0 && row + 1 == trees.tree_limit) {
 
@@ -579,10 +579,10 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
 
         return pos;
     }
-  
+
     // we hit an intermediate leaf (so just add the value to our accumulator and move to the next tree)
     if (trees.children_left[row_offset + i] < 0) {
-        
+
         // accumulate the value of this original leaf so it will land on all eventual terminal leaves
         const tfloat *vals = trees.values + (row * trees.max_nodes + i) * trees.num_outputs;
         if (leaf_value == NULL) {
@@ -601,7 +601,7 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
         row_offset += trees.max_nodes;
         i = 0;
     }
-    
+
     // split the data inds by this node's threshold
     const tfloat t = trees.thresholds[row_offset + i];
     const int f = trees.features[row_offset + i];
@@ -628,7 +628,7 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
     int *right_data_inds = data_inds + low_ptr;
     const unsigned num_right_data_inds = num_data_inds - num_left_data_inds;
     const unsigned num_right_background_data_inds = num_background_data_inds - num_left_background_data_inds;
-  
+
     // all the data went right, so we skip creating this node and just recurse right
     if (num_left_data_inds == 0) {
         return build_merged_tree_recursive(
@@ -647,7 +647,7 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
 
     // data went both ways so we create this node and recurse down both paths
     } else {
-        
+
         // build the left subtree
         const unsigned new_pos = build_merged_tree_recursive(
             out_tree, trees, data, data_missing, left_data_inds,
@@ -663,7 +663,7 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
         } else {
             out_tree.children_default[pos] = new_pos + 1;
         }
-        
+
         out_tree.features[pos] = trees.features[row_offset + i];
         out_tree.thresholds[pos] = trees.thresholds[row_offset + i];
         out_tree.node_sample_weights[pos] = num_background_data_inds;
@@ -679,7 +679,7 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
 
 
 inline void build_merged_tree(TreeEnsemble &out_tree, const ExplanationDataset &data, const TreeEnsemble &trees) {
-    
+
     // create a joint data matrix from both X and R matrices
     tfloat *joined_data = new tfloat[(data.num_X + data.num_R) * data.M];
     std::copy(data.X, data.X + data.num_X * data.M, joined_data);
@@ -719,16 +719,16 @@ struct Node {
 #define FROM_R_NOT_X 2
 
 // https://www.geeksforgeeks.org/space-and-time-efficient-binomial-coefficient/
-inline int bin_coeff(int n, int k) { 
-    int res = 1; 
+inline int bin_coeff(int n, int k) {
+    int res = 1;
     if (k > n - k)
-        k = n - k; 
-    for (int i = 0; i < k; ++i) { 
-        res *= (n - i); 
-        res /= (i + 1); 
-    } 
-    return res; 
-} 
+        k = n - k;
+    for (int i = 0; i < k; ++i) {
+        res *= (n - i);
+        res /= (i + 1);
+    }
+    return res;
+}
 
 // note this only handles single output models, so multi-output models get explained using multiple passes
 inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
@@ -752,7 +752,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
     float thres, pos_x = 0, neg_x = 0, pos_r = 0, neg_r = 0;
     char from_flag;
     unsigned M = 0, N = 0;
-    
+
     Node curr_node = mytree[node];
     feat = curr_node.feat;
     thres = curr_node.thres;
@@ -765,13 +765,13 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
         out_contribs[num_feats] += curr_node.value;
         return;
     }
-    
+
 //     if (DEBUG) {
 //       myfile << "\nNode: " << node << "\n";
 //       myfile << "x[feat]: " << x[feat] << ", r[feat]: " << r[feat] << "\n";
 //       myfile << "thres: " << thres << "\n";
 //     }
-    
+
     if (x_missing[feat]) {
         next_xnode = cd;
     } else if (x[feat] > thres) {
@@ -779,7 +779,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
     } else if (x[feat] <= thres) {
         next_xnode = cl;
     }
-    
+
     if (r_missing[feat]) {
         next_rnode = cd;
     } else if (r[feat] > thres) {
@@ -787,19 +787,19 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
     } else if (r[feat] <= thres) {
         next_rnode = cl;
     }
-    
+
     if (next_xnode != next_rnode) {
         mytree[next_xnode].from_flag = FROM_X_NOT_R;
         mytree[next_rnode].from_flag = FROM_R_NOT_X;
     } else {
         mytree[next_xnode].from_flag = FROM_NEITHER;
     }
-    
+
     // Check if x and r go the same way
     if (next_xnode == next_rnode) {
         next_node = next_xnode;
     }
-    
+
     // If not, go left
     if (next_node < 0) {
         next_node = cl;
@@ -826,8 +826,8 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
         pfeat = curr_node.pfeat;
         from_flag = curr_node.from_flag;
 
-        
-        
+
+
 //         if (DEBUG) {
 //           myfile << "\nNode: " << node << "\n";
 //           myfile << "N: " << N << ", M: " << M << "\n";
@@ -836,7 +836,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 //           myfile << "from_flag==FROM_NEITHER: " << (from_flag==FROM_NEITHER) << "\n";
 //           myfile << "feat_hist[feat]: " << feat_hist[feat] << "\n";
 //         }
-        
+
         // At a leaf
         if (cl < 0) {
             //      if (DEBUG) {
@@ -891,7 +891,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
         } else if (!x_right) {
             next_xnode = cl;
         }
-        
+
         if (r_missing[feat]) {
             next_rnode = cd;
         } else if (r_right) {
@@ -908,7 +908,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
               mytree[next_xnode].from_flag = FROM_NEITHER;
           }
         }
-        
+
         // Arriving at node from parent
         if (from_child == -1) {
             //      if (DEBUG) {
@@ -917,7 +917,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
             node_stack[ns_ctr] = node;
             ns_ctr += 1;
             next_node = -1;
-            
+
             //      if (DEBUG) {
             //        myfile << "feat_hist[feat]" << feat_hist[feat] << "\n";
             //      }
@@ -929,19 +929,19 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
                 next_node = next_rnode;
                 feat_hist[feat] -= 1;
             }
-            
+
             // x and r go the same way
             if (next_node < 0) {
                 if (next_xnode == next_rnode) {
                     next_node = next_xnode;
                 }
             }
-            
+
             // Go down one path
             if (next_node >= 0) {
                 continue;
             }
-            
+
             // Go down both paths, but go left first
             next_node = cl;
             if (next_rnode == next_node) {
@@ -955,7 +955,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
             from_child = -1;
             continue;
         }
-        
+
         // Arriving at node from child
         if (from_child != -1) {
 //             if (DEBUG) {
@@ -966,7 +966,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
             if ((next_rnode == next_xnode) || (feat_hist[feat] != 0)) {
                 next_node = pnode;
             }
-            
+
             // Came from a single path, so unroll
             if (next_node >= 0) {
 //                 if (DEBUG) {
@@ -986,7 +986,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 //                 }
                 from_child = node;
                 ns_ctr -= 1;
-                
+
                 // Unwind
                 if (feat_hist[pfeat] > 0) {
                     feat_hist[pfeat] -= 1;
@@ -1053,17 +1053,17 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 //                   myfile << "pos_lst[node]: " << pos_lst[node] << "\n";
 //                   myfile << "neg_lst[node]: " << neg_lst[node] << "\n";
 //                 }
-                
+
                 // Check if at root
                 if (node == 0) {
                     break;
                 }
-                
+
                 // Pop
                 ns_ctr -= 1;
                 next_node = node_stack[ns_ctr];
                 from_child = node;
-                
+
                 // Unwind
                 if (feat_hist[pfeat] > 0) {
                     feat_hist[pfeat] -= 1;
@@ -1090,12 +1090,12 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 
 inline void print_progress_bar(tfloat &last_print, tfloat start_time, unsigned i, unsigned total_count) {
     const tfloat elapsed_seconds = difftime(time(NULL), start_time);
-    
+
     if (elapsed_seconds > 10 && elapsed_seconds - last_print > 0.5) {
         const tfloat fraction = static_cast<tfloat>(i) / total_count;
         const double total_seconds = elapsed_seconds / fraction;
         last_print = elapsed_seconds;
-        
+
         PySys_WriteStderr(
             "\r%3.0f%%|%.*s%.*s| %d/%d [%02d:%02d<%02d:%02d]       ",
             fraction * 100, int(0.5 + fraction*20), "===================",
@@ -1210,8 +1210,8 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
 
                 for (unsigned k = 0; k < trees.tree_limit; ++k) {
                     tree_shap_indep(
-                        trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing, 
-                        tmp_out_contribs, pos_lst, neg_lst, feat_hist, memoized_weights, 
+                        trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing,
+                        tmp_out_contribs, pos_lst, neg_lst, feat_hist, memoized_weights,
                         node_stack, node_trees + k * trees.max_nodes
                     );
                 }
@@ -1327,7 +1327,7 @@ inline void dense_tree_interactions_path_dependent(const TreeEnsemble& trees, co
             }
         }
     }
-    
+
     // build an interaction explanation for each sample
     tfloat *instance_out_contribs;
     TreeEnsemble tree;
@@ -1390,7 +1390,7 @@ inline void dense_tree_interactions_path_dependent(const TreeEnsemble& trees, co
 
 /**
  * This runs Tree SHAP with a global path conditional dependence assumption.
- * 
+ *
  * By first merging all the trees in a tree ensemble into an equivalent single tree
  * this method allows arbitrary marginal transformations and also ensures that all the
  * evaluations of the model are consistent with some training data point.
@@ -1401,7 +1401,7 @@ inline void dense_global_path_dependent(const TreeEnsemble& trees, const Explana
     // allocate space for our new merged tree (we save enough room to totally split all samples if need be)
     TreeEnsemble merged_tree;
     merged_tree.allocate(1, (data.num_X + data.num_R) * 2, trees.num_outputs);
-    
+
     // collapse the ensemble of trees into a single tree that has the same behavior
     // for all the X and R samples in the dataset
     build_merged_tree(merged_tree, data, trees);
@@ -1415,7 +1415,7 @@ inline void dense_global_path_dependent(const TreeEnsemble& trees, const Explana
     for (unsigned i = 0; i < data.num_X; ++i) {
         instance_out_contribs = out_contribs + i * (data.M + 1) * trees.num_outputs;
         data.get_x_instance(instance, i);
-       
+
         // since we now just have a single merged tree we can just use the tree_path_dependent algorithm
         tree_shap(merged_tree, instance, instance_out_contribs, 0, 0);
 
@@ -1445,7 +1445,7 @@ inline void dense_tree_shap(const TreeEnsemble& trees, const ExplanationDataset 
                 std::cerr << "FEATURE_DEPENDENCE::independent does not support interactions!\n";
             } else dense_independent(trees, data, out_contribs, transform);
             return;
-        
+
         case FEATURE_DEPENDENCE::tree_path_dependent:
             if (interactions) dense_tree_interactions_path_dependent(trees, data, out_contribs, transform);
             else dense_tree_path_dependent(trees, data, out_contribs, transform);

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -77,16 +77,17 @@ class Tree(Explainer):
             does not require a background dataset and so is used by default when no background dataset is provided.
 
         model_output : "raw", "probability", "log_loss", or model method name
-            What output of the model should be explained. If "raw" then we explain the raw output of the
-            trees, which varies by model. For regression models "raw" is the standard output, for binary
-            classification in XGBoost this is the log odds ratio. If model_output is the name of a supported
-            prediction method on the model object then we explain the output of that model method name.
-            For example model_output="predict_proba" explains the result of calling model.predict_proba.
-            If "probability" then we explain the output of the model transformed into probability space
-            (note that this means the SHAP values now sum to the probability output of the model). If "logloss"
+            What output of the model should be explained. If "raw", then we explain the raw output of the
+            trees, which varies by model. For regression models, "raw" is the standard output. For binary
+            classification in XGBoost, this is the log odds ratio. If model_output is the name of a supported
+            prediction method on the model object, then we explain the output of that model method name.
+            For example, model_output="predict_proba" explains the result of calling `model.predict_proba`.
+            If "probability", then we explain the output of the model transformed into probability space
+            (note that this means the SHAP values now sum to the probability output of the model). If "log_loss",
             then we explain the log base e of the model loss function, so that the SHAP values sum up to the
             log loss of the model for each sample. This is helpful for breaking down model performance by feature.
-            Currently the probability and logloss options are only supported when feature_dependence="independent".
+            Currently the "probability" and "log_loss" options are only supported when
+            feature_dependence="independent".
 
         Examples
         --------

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -149,7 +149,7 @@ class Tree(Explainer):
         self.model = TreeEnsemble(model, self.data, self.data_missing, model_output)
         self.model_output = model_output
         #self.model_output = self.model.model_output # this allows the TreeEnsemble to translate model outputs types by how it loads the model
-        
+
         self.approximate = approximate
 
         if feature_perturbation not in feature_perturbation_codes:
@@ -338,7 +338,7 @@ class Tree(Explainer):
                                          "See https://github.com/slundberg/shap/issues/580") from e
 
                 if check_additivity and self.model.model_output == "raw":
-                    xgb_tree_limit = tree_limit // self.model.num_stacked_models 
+                    xgb_tree_limit = tree_limit // self.model.num_stacked_models
                     model_output_vals = self.model.original_model.predict(
                         X, ntree_limit=xgb_tree_limit, output_margin=True,
                         validate_features=False
@@ -841,7 +841,7 @@ class TreeEnsemble:
             # 'best_ntree_limit' is problematic
             # https://github.com/dmlc/xgboost/issues/6615
             if hasattr(model, 'best_iteration'):
-                trees_per_iteration = xgb_loader.num_class if xgb_loader.num_class > 0 else 1 
+                trees_per_iteration = xgb_loader.num_class if xgb_loader.num_class > 0 else 1
                 self.tree_limit = (getattr(model, "best_iteration", None) + 1) * trees_per_iteration
             else:
                 self.tree_limit = getattr(model, "best_ntree_limit", None)
@@ -1672,4 +1672,3 @@ class CatBoostTreeModelLoader:
                             }, data=data, data_missing=data_missing))
 
         return trees
-

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -98,7 +98,7 @@ class Tree(Explainer):
             self.data_feature_names = list(data.columns)
 
         masker = data
-        super(Tree, self).__init__(model, masker, feature_names=feature_names)
+        super().__init__(model, masker, feature_names=feature_names)
 
         if type(self.masker) is maskers.Independent:
             data = self.masker.data

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1366,7 +1366,7 @@ class SingleTree:
 
         # Re-compute the number of samples that pass through each node if we are given data
         if data is not None and data_missing is not None:
-            self.node_sample_weight[:] = 0.0
+            self.node_sample_weight.fill(0.0)
             _cext.dense_tree_update_weights(
                 self.children_left, self.children_right, self.children_default, self.features,
                 self.thresholds, self.values, 1, self.node_sample_weight, data, data_missing
@@ -1507,7 +1507,7 @@ class XGBTreeModelLoader(object):
 
             # load the stat nodes
             self.loss_chg.append(np.zeros(self.num_nodes[i], dtype=np.float32))
-            self.sum_hess.append(np.zeros(self.num_nodes[i], dtype=np.float32))
+            self.sum_hess.append(np.zeros(self.num_nodes[i], dtype=np.float64))
             self.base_weight.append(np.zeros(self.num_nodes[i], dtype=np.float32))
             self.leaf_child_cnt.append(np.zeros(self.num_nodes[i], dtype=int))
             for j in range(self.num_nodes[i]):

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -796,7 +796,7 @@ def test_provided_background_tree_path_dependent():
     xgboost = pytest.importorskip("xgboost")
     np.random.seed(10)
 
-    X, y = shap.datasets.iris(n_points=100)
+    X, y = shap.datasets.adult(n_points=100)
     dtrain = xgboost.DMatrix(X, label=y, feature_names=X.columns)
 
     params = {

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -790,35 +790,30 @@ def test_multi_target_extra_trees():
 
 
 def test_provided_background_tree_path_dependent():
+    """Tests xgboost explainer when feature_perturbation is tree_path_dependent and when background
+    data is provided.
+    """
     xgboost = pytest.importorskip("xgboost")
     np.random.seed(10)
 
-    X, y = shap.datasets.iris()
-    X = X[:100]
-    y = y[:100]
-    train_x, test_x, train_y, _ = sklearn.model_selection.train_test_split(X, y, random_state=1)
-    feature_names = ["a", "b", "c", "d"]
-    dtrain = xgboost.DMatrix(train_x, label=train_y, feature_names=feature_names)
-    dtest = xgboost.DMatrix(test_x, feature_names=feature_names)
+    X, y = shap.datasets.iris(n_points=100)
+    dtrain = xgboost.DMatrix(X, label=y, feature_names=X.columns)
 
     params = {
-        'booster': 'gbtree',
-        'objective': 'binary:logistic',
-        'max_depth': 4,
-        'eta': 0.1,
-        'nthread': -1,
-        'silent': 1
+        "booster": "gbtree",
+        "objective": "binary:logistic",
+        "max_depth": 2,
+        "eta": 0.05,
+        "nthread": -1,
+        "random_state": 42,
     }
+    bst = xgboost.train(params=params, dtrain=dtrain, num_boost_round=10)
+    pred_scores = bst.predict(dtrain, output_margin=True)
 
-    bst = xgboost.train(params=params, dtrain=dtrain, num_boost_round=100)
-
-    explainer = shap.TreeExplainer(bst, test_x, feature_perturbation="tree_path_dependent")
-    diffs = explainer.expected_value + \
-            explainer.shap_values(test_x).sum(1) - bst.predict(dtest, output_margin=True)
+    explainer = shap.TreeExplainer(bst, data=X, feature_perturbation="tree_path_dependent")
+    diffs = explainer.expected_value + explainer.shap_values(X).sum(axis=1) - pred_scores
     assert np.max(np.abs(diffs)) < 1e-4, "SHAP values don't sum to model output!"
-    assert np.abs(explainer.expected_value - bst.predict(dtest,
-                                                         output_margin=True).mean()) < 1e-6, \
-        "Bad expected_value!"
+    assert np.abs(explainer.expected_value - pred_scores.mean()) < 1e-6, "Bad expected_value!"
 
 
 def test_provided_background_independent():


### PR DESCRIPTION
Resolves #48 .

## Changes

Please see individual commits in the PR for the changelog.

* The main fix involves specifying the dtype of the `node_sample_weight` numpy array to be double type. This makes it compatible with the type declared in the cext (`_cext.cc`). Previously, the array was declared to be float32 in Python, and double / float64 in the C extension (`_cext_dense_tree_update_weights` C function). When the dtypes don't match up, it causes the C extension to not be able to properly pass the updated weights array back to Python..
* Updated the `test_provided_background_tree_path_dependent` test to use the `adult()` dataset instead of `iris()`, and under-specify the model (drastically lower the xgboost depth and `num_boost_rounds`, otherwise we end up with too many leaves/terminal nodes in the model and there'll be some nodes with 0 weights).
* Some minor docs and whitespace fixes.


## Some history

The actual manifestation of this problem comes from the `test_provided_background_tree_path_dependent` test failing.
slundberg tried to resolve this problem in PR slundberg#2781, but didn't work.

The actual root cause is what is presented in #48 , that no matter what background dataset was provided, the `node_sample_weight` array would still always end up as an array of 0's, thus failing the test.