### PR TITLE
fix: ruff rule F821 (undefined name)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,5 @@ select = ["F"]
 ignore = [
   "F401", # unused imports
   "F811", # Redefinition of unused variable
-  "F821", # Undefined name
   "F841", # Local variables assigned but unused
 ]

--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -2,19 +2,20 @@ from .. import Explanation
 from ..utils import OpChain
 from . import colors
 import numpy as np
+import matplotlib.pyplot as pl
 
 
 def convert_color(color):
     try:
         color = pl.get_cmap(color)
-    except:
+    except Exception:
         pass
-    
+
     if color == "shap_red":
         color = colors.red_rgb
     elif color == "shap_blue":
         color = colors.blue_rgb
-    
+
     return color
 
 def convert_ordering(ordering, shap_values):


### PR DESCRIPTION
Related to Issue #21, and is a continuation of PR #25 when ruff was initially introduced to the project.

**Dependencies**: PR #53 (deprecating MimicExplainer) must be merged in first, because that's one of the main offenders of F821. ✅

---

## Changes

The changes are quite major considering it involves mostly dead / unreachable code. Requesting a thorough review, but any review (even partial!) would be appreciated. I'll leave review comments in the relevant places later on to make code review a little easier for you guys, but here's the tl;dr:

1. <s>`Explanation.hstack` method was using a non-existent variable "axis" (probably copied from the other helper methods like `sum`). The implementation as it is didn't make any sense, so I modified it to what I think made the most sense, which is to hstack the inner arrays and return a new Explanation object.</s> ✅ **DONE in PR #86** 
2. `beeswarm` plot function was using non-existent variables like `title`, `sort`, `plot_type` which came from the `summary_legacy()` function, within an unreachable code block meant for SHAP interaction values. I've commented out the block for now to prevent ruff from complaining, but we should look into re-implementing this functionality. -> Issue #56.
3. <s>I revamped`violin` plot code quite a bit. The original `violin` was essentially a copy-paste from the `summary_legacy()` function, so there's a lot of redundant code (including a call to a "non-existent" `summary()` function) checking for "bar" or "dot" plot types. These have all been removed. Violin plots don't support multioutputs (only bar plots support this), so that section has been removed as well.</s> ✅ **DONE in PR #87** 
    - <s>I'll note that the code for `violin` is still in the "legacy" style. For e.g., it still accepts `shap_values` as a numpy array. Whereas `beeswarm` only takes in `Explanation` objects, which I think we should align to that convention. -> Issue #55.</s>
5. <s>The plot tests for violin in `test_violin.py` and `test_summary.py` were revamped. In particular, the original test was just an empty plot...</s> ✅ **DONE in PR #87** 