### PR TITLE
Separate out tests of optional dependencies, add new unit test job

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,9 +34,9 @@ jobs:
         uses: codecov/codecov-action@v3
 
   run_tests_core:
-    name: Unit tests (core only)
+    name: run_tests (core only)
     # Run tests with only the core dependencies, to ensure we
-    # cover the latest version of numpy/pandas
+    # cover the latest version of numpy/pandas. See #46
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,7 +37,6 @@ jobs:
     name: Unit tests (core only)
     # Run tests with only the core dependencies, to ensure we
     # cover the latest version of numpy/pandas
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -48,9 +47,7 @@ jobs:
       - name: Install core dependencies
         run: |
           python -m pip install --upgrade pip
-          # Only core dependencies, Do not include the full "test" group
-          pip install -e '.[plots]'
-          pip install pytest, pytest-mpl
+          pip install -e '.[test-core,plots]'
       - name: Test with pytest
         run: |
           python -m pytest --durations=20

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,3 +32,25 @@ jobs:
           --cov-report=xml --cov-report=term-missing
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+
+  run_tests_core:
+    name: Unit tests (core only)
+    # Run tests with only the core dependencies, to ensure we
+    # cover the latest version of numpy/pandas
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install core dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Only core dependencies, Do not include the full "test" group
+          pip install -e '.[plots]'
+          pip install pytest, pytest-mpl
+      - name: Test with pytest
+        run: |
+          python -m pytest --durations=20

--- a/setup.py
+++ b/setup.py
@@ -152,25 +152,6 @@ def run_setup(
         except Exception as e:
             raise Exception("Error building cuda module: " + repr(e)) from e
 
-    tests_require = [
-        # core testing libraries
-        "pytest",
-        "pytest-mpl",
-        "pytest-cov",
-        # optional dependencies
-        "xgboost",
-        "lightgbm",
-        "catboost",
-        "pyspark",
-        "pyod",
-        "transformers",
-        "torch",
-        "torchvision",
-        "tensorflow",
-        "sentencepiece",
-        "opencv-python",
-    ]
-
     extras_require = {
         'plots': [
             'matplotlib',
@@ -186,9 +167,27 @@ def run_setup(
             'sphinx_rtd_theme',
             'sphinx',
             'nbsphinx',
-        ]
+        ],
+        'test-core': [
+            "pytest",
+            "pytest-mpl",
+            "pytest-cov",
+        ],
+        'test-extras': [
+            "xgboost",
+            "lightgbm",
+            "catboost",
+            "pyspark",
+            "pyod",
+            "transformers",
+            "torch",
+            "torchvision",
+            "tensorflow",
+            "sentencepiece",
+            "opencv-python",
+        ],
     }
-    extras_require['test'] = tests_require
+    extras_require['test'] = extras_require['test-core'] + extras_require['test-extras']
     extras_require['all'] = list(set(i for val in extras_require.values() for i in val))
 
     setup(

--- a/tests/explainers/test_linear.py
+++ b/tests/explainers/test_linear.py
@@ -35,6 +35,7 @@ def test_tied_pair_new():
     assert np.abs(explainer.shap_values(X) - np.array([0.5, 0.5, 0])).max() < 0.05
 
 def test_wrong_masker():
+    pytest.importorskip("cv2")
     with pytest.raises(NotImplementedError):
         shap.explainers.Linear((0, 0), shap.maskers.Image("blur(10,10)", (10, 10, 3)))
 

--- a/tests/explainers/test_linear.py
+++ b/tests/explainers/test_linear.py
@@ -35,7 +35,6 @@ def test_tied_pair_new():
     assert np.abs(explainer.shap_values(X) - np.array([0.5, 0.5, 0])).max() < 0.05
 
 def test_wrong_masker():
-    pytest.importorskip("cv2")
     with pytest.raises(NotImplementedError):
         shap.explainers.Linear((0, 0), shap.maskers.Fixed())
 


### PR DESCRIPTION
Closes #46

Defines two dependency groups, `test-core` and `test-extras`. The group `tests` remains as the union of both.

Adds an extra CI job to run tests with core dependencies only.