### PR TITLE
tests: remove cv2 dependence for testing wrong masker #64

### DIFF
--- a/tests/explainers/test_linear.py
+++ b/tests/explainers/test_linear.py
@@ -36,7 +36,7 @@ def test_tied_pair_new():
 
 def test_wrong_masker():
     with pytest.raises(NotImplementedError):
-        shap.explainers.Linear((0, 0), shap.maskers.Image("blur(10,10)", (10, 10, 3)))
+        shap.explainers.Linear((0, 0), shap.maskers.Fixed())
 
 def test_tied_triple():
     np.random.seed(0)


### PR DESCRIPTION
Resolves #64. See https://github.com/dsgibbons/shap/pull/61/files#diff-aaac45c56f18d99426abc36ac5c74ec085677e8349ebd0a23abdfa5f66bb4377 for further details.

Replace `shap.maskers.Image` with `shap.maskers.Fixed` as `Fixed` does not require non-essential dependencies like `cv2`.