### PR TITLE
Chore: Disable fail-fast behaviour of matrix CI tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Our test suite runs on several versions of python. However, at present, we only see the test results for whichever run happens to fail first, as the others are cancelled. This is problematic, as we may miss warnings and test failures that occur in some versions of python but not others. 

I think this was the root cause of a slight issue I had with PR #9 . The PR intended to fix some DeprecationWarnings. The test suite showed that the NumbaDeprecationWarnings had been fixed; however, the warnings still remained on higher versions of python, which I missed at the time.