### PR TITLE
Add support for python 3.11

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -225,6 +225,7 @@ def run_setup(
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
         ],
         zip_safe=False
         # python_requires='>3.0' we will add this at some point


### PR DESCRIPTION
Closes #71 

This may require a fair bit of work before this is ready, for example fixing various deprecations from other libraries. We could continually rebase this branch on top of master to see how the test suite runs on 3.11.