### PR TITLE
Chore: Simplify pytest code coverage config

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest --durations=20 \
-          --cov-report=xml --cov-report=term-missing
+          --cov=shap --cov-report=xml --cov-report=term-missing
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
 
@@ -51,4 +51,4 @@ jobs:
           pip install -e '.[test-core,plots]'
       - name: Test with pytest
         run: |
-          python -m pytest --durations=20
+          python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "oldest-supported-numpy", "packaging>20.9"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "--mpl --cov=shap"
+addopts = "--mpl"
 testpaths = ["tests"]
 
 [tool.ruff]


### PR DESCRIPTION
A very small bugbear change, to simplify the output of pytest when tests are run locally.

Configures pytest so that code coverage is not shown by default, but remains visible on the appropriate CI jobs.