### PR TITLE
Fix failing test from incorrect comparison of bools and ints

### DIFF
--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -113,11 +113,8 @@ class Exact(Explainer):
             outputs = fm(extended_delta_indexes, zero_index=0, batch_size=batch_size)
 
             # Shapley values
-            def _integer_equal(x, number):
-                # Care: Need to distinguish between `True` and `1`
-                return x == number and not isinstance(x, bool)
-
-            if interactions is False or _integer_equal(interactions, 1):
+            # Care: Need to distinguish between `True` and `1`
+            if interactions is False or (interactions == 1 and interactions is not True):
 
                 # loop over all the outputs to update the rows
                 coeff = shapley_coefficients(len(inds))
@@ -126,7 +123,7 @@ class Exact(Explainer):
                 _compute_grey_code_row_values(row_values, mask, inds, outputs, coeff, extended_delta_indexes, MaskedModel.delta_mask_noop_value)
 
             # Shapley-Taylor interaction values
-            elif interactions is True or _integer_equal(interactions, 2):
+            elif interactions is True or interactions == 2:
 
                 # loop over all the outputs to update the rows
                 coeff = shapley_coefficients(len(inds))

--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -113,7 +113,11 @@ class Exact(Explainer):
             outputs = fm(extended_delta_indexes, zero_index=0, batch_size=batch_size)
 
             # Shapley values
-            if interactions is False or interactions == 1:
+            def _integer_equal(x, number):
+                # Care: Need to distinguish between `True` and `1`
+                return x == number and not isinstance(x, bool)
+
+            if interactions is False or _integer_equal(interactions, 1):
 
                 # loop over all the outputs to update the rows
                 coeff = shapley_coefficients(len(inds))
@@ -122,7 +126,7 @@ class Exact(Explainer):
                 _compute_grey_code_row_values(row_values, mask, inds, outputs, coeff, extended_delta_indexes, MaskedModel.delta_mask_noop_value)
 
             # Shapley-Taylor interaction values
-            elif interactions is True or interactions == 2:
+            elif interactions is True or _integer_equal(interactions, 2):
 
                 # loop over all the outputs to update the rows
                 coeff = shapley_coefficients(len(inds))


### PR DESCRIPTION
This fixes a rather subtle bug that was inadvertently introduced by #27.

Related: #4

There is a check whether the variable `interactions` is equal to `1`. Currently, this statment also passes if `interactions` is equal to `True`, but this is unintentional. It's a rather nuanced as a `bool` is a subclass of an `int`, so `isinstance(interactions, int)` is not enough. 

Side fun fact: this comparison was previously achieved with `interactions is 1`, which is not safe but _may_ work some of the time depending on the python implmentation. Here's a fun python phenomenon:

```
>>> a = 1
>>> b = 1
>>> a is b
True
>>> a = 99999999
>>> b = 99999999
>>> a is b
False
```

