### PR TITLE
Chore: Upload pytest-mpl failures as artifacts

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -33,11 +33,12 @@ jobs:
           --cov=shap --cov-report=xml --cov-report=term-missing \
           --mpl-generate-summary=html --mpl-results-path=./mpl-results
       - name: Upload mpl test report
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: mpl-results
           path: mpl-results/
+          if-no-files-found: ignore
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
 
@@ -58,4 +59,12 @@ jobs:
           pip install -e '.[test-core,plots]'
       - name: Test with pytest
         run: |
-          python -m pytest
+          python -m pytest \
+          --mpl-generate-summary=html --mpl-results-path=./mpl-results
+      - name: Upload mpl test report
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: mpl-results
+          path: mpl-results/
+          if-no-files-found: ignore

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -59,12 +59,4 @@ jobs:
           pip install -e '.[test-core,plots]'
       - name: Test with pytest
         run: |
-          python -m pytest \
-          --mpl-generate-summary=html --mpl-results-path=./mpl-results
-      - name: Upload mpl test report
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: mpl-results-core
-          path: mpl-results/
-          if-no-files-found: ignore
+          python -m pytest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,7 +36,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: mpl-results
+          name: mpl-results-${{ matrix.python-version }}
           path: mpl-results/
           if-no-files-found: ignore
       - name: Upload coverage to Codecov
@@ -65,6 +65,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: mpl-results
+          name: mpl-results-core
           path: mpl-results/
           if-no-files-found: ignore

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,7 +30,14 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest --durations=20 \
-          --cov=shap --cov-report=xml --cov-report=term-missing
+          --cov=shap --cov-report=xml --cov-report=term-missing \
+          --mpl-generate-summary=html --mpl-results-path=./mpl-results
+      - name: Upload mpl test report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: mpl-results
+          path: mpl-results/
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
 


### PR DESCRIPTION
Minor change that should make it easier to review test results that relate to pytest-mpl failures, without having to re-run tests locally.