### PR TITLE
Cache pip dependencies on CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,10 +36,21 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: setup.py
+      - name: debug cache size
+        run: |
+          pip cache dir
+          pip cache dir | xargs du -sh
       - name: Install dependencies
         run: |
+          pip cache dir
+          pip cache dir | xargs du -sh
           python -m pip install --upgrade pip
+          pip cache dir | xargs du -sh
           pip install --upgrade --upgrade-strategy eager -e '.[test,plots]'
+      - name: debug cache size
+        run: |
+          pip cache dir
+          pip cache dir | xargs du -sh
       - name: Test with pytest
         run: |
           python -m pytest --durations=20 \
@@ -68,10 +79,19 @@ jobs:
           python-version: "3.10"
           cache: pip
           cache-dependency-path: setup.py
+      - name: debug cache size
+        run: |
+          pip cache dir
+          pip cache dir | xargs du -sh
       - name: Install core dependencies
         run: |
           python -m pip install --upgrade pip
+          pip cache dir | xargs du -sh
           pip install --upgrade --upgrade-strategy eager -e '.[test-core,plots]'
+      - name: debug cache size
+        run: |
+          pip cache dir
+          pip cache dir | xargs du -sh
       - name: Test with pytest
         run: |
           python -m pytest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -77,21 +77,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-          cache: pip
-          cache-dependency-path: setup.py
-      - name: debug cache size
-        run: |
-          pip cache dir
-          pip cache dir | xargs du -sh  || echo failed
       - name: Install core dependencies
         run: |
           python -m pip install --upgrade pip
-          pip cache dir | xargs du -sh  || echo failed
           pip install --upgrade --upgrade-strategy eager -e '.[test-core,plots]'
-      - name: debug cache size
-        run: |
-          pip cache dir
-          pip cache dir | xargs du -sh  || echo failed
       - name: Test with pytest
         run: |
           python -m pytest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: debug python size (fresh)
         run: |
           ls -lah ${{ env.pythonLocation }}
-          du ${{ env.pythonLocation }} || echo failed
+          du -sh ${{ env.pythonLocation }} || echo failed
       - name: Cache python installation
         uses: actions/cache@v3
         with:
@@ -46,7 +46,7 @@ jobs:
       - name: debug python size (after cache restore)
         run: |
           ls -lah ${{ env.pythonLocation }}
-          du ${{ env.pythonLocation }} || echo failed
+          du -sh ${{ env.pythonLocation }} || echo failed
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -54,7 +54,7 @@ jobs:
       - name: debug python size (after install)
         run: |
           ls -lah ${{ env.pythonLocation }}
-          du ${{ env.pythonLocation }} || echo failed
+          du -sh ${{ env.pythonLocation }} || echo failed
       - name: Test with pytest
         run: |
           # Fewer tests, for speedy testing

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            # Select libraries that have slowest build time (s) for smallest storage cost (MB)
+            # Only cache a subset of libraries, ensuring cache size remains under 10GB. See #42
             ${{ env.pythonLocation }}/**/site-packages/pyspark*
             ${{ env.pythonLocation }}/**/site-packages/nvidia*
             ${{ env.pythonLocation }}/**/site-packages/torch*
@@ -52,8 +52,7 @@ jobs:
           pip install --upgrade --upgrade-strategy eager -e '.[test,plots]'
       - name: Test with pytest
         run: |
-          # Temp change for faster tests
-          python -m pytest -k explanation_hstack --durations=20 \
+          python -m pytest --durations=20 \
           --cov=shap --cov-report=xml --cov-report=term-missing \
           --mpl-generate-summary=html --mpl-results-path=./mpl-results
       - name: Upload mpl test report

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-0
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-0
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,21 +34,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Debug info
-        run: |
-          echo ${{ env.pythonLocation }}
-          ls -lah ${{ env.pythonLocation }}
-          echo ${{ env.pythonLocation }}
       - name: Cache python libs
         uses: actions/cache@v3
         with:
           path: |
-            ${{ env.pythonLocation }}/**/site-packages/torch*
-            ${{ env.pythonLocation }}/**/site-packages/tensorflow*
-            ${{ env.pythonLocation }}/**/site-packages/xgboost*
+            # Select libraries that have slowest build time (s) for smallest storage cost (MB)
             ${{ env.pythonLocation }}/**/site-packages/pyspark*
             ${{ env.pythonLocation }}/**/site-packages/nvidia*
-            ${{ env.pythonLocation }}/**/site-packages/pyspark*
+            ${{ env.pythonLocation }}/**/site-packages/torch*
+          #  ${{ env.pythonLocation }}/**/site-packages/tensorflow*
+          #  ${{ env.pythonLocation }}/**/site-packages/xgboost*
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-0
       - name: Install dependencies
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,11 +34,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache python env
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
+          cache: pip
+          cache-dependency-path: setup.py
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -69,11 +66,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: Cache python env
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-core
+          cache: pip
+          cache-dependency-path: setup.py
       - name: Install core dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,12 +34,21 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache python installation
-        # Only cache 3 envs, to stay under github's 10GB cache storage limit
-        if: contains(fromJSON('["3.7", "3.10", "3.11"]'), matrix.python-version)
+      - name: Debug info
+        run: |
+          echo ${{ env.pythonLocation }}
+          ls -lah ${{ env.pythonLocation }}
+          echo ${{ env.pythonLocation }}
+      - name: Cache python libs
         uses: actions/cache@v3
         with:
-          path: ${{ env.pythonLocation }}
+          path: |
+            ${{ env.pythonLocation }}/**/site-packages/torch*
+            ${{ env.pythonLocation }}/**/site-packages/tensorflow*
+            ${{ env.pythonLocation }}/**/site-packages/xgboost*
+            ${{ env.pythonLocation }}/**/site-packages/pyspark*
+            ${{ env.pythonLocation }}/**/site-packages/nvidia*
+            ${{ env.pythonLocation }}/**/site-packages/pyspark*
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-0
       - name: Install dependencies
         run: |
@@ -48,7 +57,8 @@ jobs:
           pip install --upgrade --upgrade-strategy eager -e '.[test,plots]'
       - name: Test with pytest
         run: |
-          python -m pytest --durations=20 \
+          # Temp change for faster tests
+          python -m pytest -k explanation_hstack --durations=20 \
           --cov=shap --cov-report=xml --cov-report=term-missing \
           --mpl-generate-summary=html --mpl-results-path=./mpl-results
       - name: Upload mpl test report

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -69,10 +69,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Cache python env
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-core
       - name: Install core dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[test-core,plots]'
+          pip install --upgrade --upgrade-strategy eager -e '.[test-core,plots]'
       - name: Test with pytest
         run: |
           python -m pytest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,27 +34,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: debug python size (fresh)
-        run: |
-          ls -lah ${{ env.pythonLocation }}
-          du -sh ${{ env.pythonLocation }} || echo failed
       - name: Cache python installation
+        # Only cache a subset of python envs: repo cache total size limited to 10GB, each env is ~3GB
+        if: contains(fromJSON('["3.9", "3.10", "3.11"]'), github.event_name)
         uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-0
-      - name: debug python size (after cache restore)
-        run: |
-          ls -lah ${{ env.pythonLocation }}
-          du -sh ${{ env.pythonLocation }} || echo failed
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -e '.[test,plots]'
-      - name: debug python size (after install)
-        run: |
-          ls -lah ${{ env.pythonLocation }}
-          du -sh ${{ env.pythonLocation }} || echo failed
       - name: Test with pytest
         run: |
           # Fewer tests, for speedy testing
@@ -71,7 +61,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
 
-  # New pointless line
   run_tests_core:
     name: run_tests (core only)
     # Run tests with only the core dependencies, to ensure we

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
 
+  # New pointless line
   run_tests_core:
     name: run_tests (core only)
     # Run tests with only the core dependencies, to ensure we

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache python installation
-        # Only cache a subset of python envs: repo cache total size limited to 10GB, each env is ~3GB
-        if: contains(fromJSON('["3.7", "3.10", "3.11"]'), github.event_name)
+        # Only cache 3 envs, to stay under github's 10GB cache storage limit
+        if: contains(fromJSON('["3.7", "3.10", "3.11"]'), matrix.python-version)
         uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
@@ -44,11 +44,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          # Use "eager" update strategy in case cached dependencies are outdated
           pip install --upgrade --upgrade-strategy eager -e '.[test,plots]'
       - name: Test with pytest
         run: |
-          # Fewer tests, for speedy testing
-          python -m pytest -k explanation_hstack --durations=20 \
+          python -m pytest --durations=20 \
           --cov=shap --cov-report=xml --cov-report=term-missing \
           --mpl-generate-summary=html --mpl-results-path=./mpl-results
       - name: Upload mpl test report
@@ -68,14 +68,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install core dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade --upgrade-strategy eager -e '.[test-core,plots]'
+          pip install -e '.[test-core,plots]'
       - name: Test with pytest
         run: |
           python -m pytest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,10 +34,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache python env
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[test,plots]'
+          pip install --upgrade --upgrade-strategy eager -e '.[test,plots]'
       - name: Test with pytest
         run: |
           python -m pytest --durations=20 \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,18 +39,18 @@ jobs:
       - name: debug cache size
         run: |
           pip cache dir
-          pip cache dir | xargs du -sh
+          pip cache dir | xargs du -sh || echo failed
       - name: Install dependencies
         run: |
           pip cache dir
-          pip cache dir | xargs du -sh
+          pip cache dir | xargs du -sh  || echo failed
           python -m pip install --upgrade pip
-          pip cache dir | xargs du -sh
+          pip cache dir | xargs du -sh  || echo failed
           pip install --upgrade --upgrade-strategy eager -e '.[test,plots]'
       - name: debug cache size
         run: |
           pip cache dir
-          pip cache dir | xargs du -sh
+          pip cache dir | xargs du -sh || echo failed
       - name: Test with pytest
         run: |
           python -m pytest --durations=20 \
@@ -82,16 +82,16 @@ jobs:
       - name: debug cache size
         run: |
           pip cache dir
-          pip cache dir | xargs du -sh
+          pip cache dir | xargs du -sh  || echo failed
       - name: Install core dependencies
         run: |
           python -m pip install --upgrade pip
-          pip cache dir | xargs du -sh
+          pip cache dir | xargs du -sh  || echo failed
           pip install --upgrade --upgrade-strategy eager -e '.[test-core,plots]'
       - name: debug cache size
         run: |
           pip cache dir
-          pip cache dir | xargs du -sh
+          pip cache dir | xargs du -sh  || echo failed
       - name: Test with pytest
         run: |
           python -m pytest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,23 +34,27 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: setup.py
-      - name: debug cache size
+      - name: debug python size (fresh)
         run: |
-          pip cache dir
-          pip cache dir | xargs du -sh || echo failed
+          ls -lah ${{ env.pythonLocation }}
+          du ${{ env.pythonLocation }} || echo failed
+      - name: Cache python installation
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-0
+      - name: debug python size (after cache restore)
+        run: |
+          ls -lah ${{ env.pythonLocation }}
+          du ${{ env.pythonLocation }} || echo failed
       - name: Install dependencies
         run: |
-          pip cache dir
-          pip cache dir | xargs du -sh  || echo failed
           python -m pip install --upgrade pip
-          pip cache dir | xargs du -sh  || echo failed
           pip install --upgrade --upgrade-strategy eager -e '.[test,plots]'
-      - name: debug cache size
+      - name: debug python size (after install)
         run: |
-          pip cache dir
-          pip cache dir | xargs du -sh || echo failed
+          ls -lah ${{ env.pythonLocation }}
+          du ${{ env.pythonLocation }} || echo failed
       - name: Test with pytest
         run: |
           # Fewer tests, for speedy testing

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -53,7 +53,8 @@ jobs:
           pip cache dir | xargs du -sh || echo failed
       - name: Test with pytest
         run: |
-          python -m pytest --durations=20 \
+          # Fewer tests, for speedy testing
+          python -m pytest -k explanation_hstack --durations=20 \
           --cov=shap --cov-report=xml --cov-report=term-missing \
           --mpl-generate-summary=html --mpl-results-path=./mpl-results
       - name: Upload mpl test report

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache python env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Cache python env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-core

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Cache python installation
         # Only cache a subset of python envs: repo cache total size limited to 10GB, each env is ~3GB
-        if: contains(fromJSON('["3.9", "3.10", "3.11"]'), github.event_name)
+        if: contains(fromJSON('["3.7", "3.10", "3.11"]'), github.event_name)
         uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}


### PR DESCRIPTION
Supports #42.

Adds caching of pip dependencies for faster CI times. Reduces time to install dependencies from ~4min30 to ~3mins. See [discussion on #42](https://github.com/dsgibbons/shap/issues/42#issuecomment-1571735472) for measured timings for alternative ideas, and discussion of total cache limits.