### PR TITLE
fix: Explanation hstack undefined name error

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -583,25 +583,24 @@ class Explanation(metaclass=MetaExplanation):
         """
         assert self.shape[0] == other.shape[0], "Can't hstack explanations with different numbers of rows!"
         assert np.max(np.abs(self.base_values - other.base_values)) < 1e-6, "Can't hstack explanations with different base values!"
-        
+
         new_exp = Explanation(
-            np.hstack([self.values, other.values]),
-            np.hstack([self.values, other.values]),
-            self.base_values,
-            self.data,
-            self.display_data,
-            self.instance_names,
-            self.feature_names,
-            self.output_names,
-            self.output_indexes,
-            self.lower_bounds,
-            self.upper_bounds,
-            self.error_std,
-            self.main_effects,
-            self.hierarchical_values,
-            self.clustering
+            values=np.hstack([self.values, other.values]),
+            base_values=self.base_values,
+            data=self.data,
+            display_data=self.display_data,
+            instance_names=self.instance_names,
+            feature_names=self.feature_names,
+            output_names=self.output_names,
+            output_indexes=self.output_indexes,
+            lower_bounds=self.lower_bounds,
+            upper_bounds=self.upper_bounds,
+            error_std=self.error_std,
+            main_effects=self.main_effects,
+            hierarchical_values=self.hierarchical_values,
+            clustering=self.clustering,
         )
-        return self._numpy_func("min", axis=axis)
+        return new_exp
 
     # def reshape(self, *args):
     #     return self._numpy_func("reshape", newshape=args)

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -1,0 +1,59 @@
+"""This file contains tests for the `shap._explanation` module.
+"""
+
+import numpy as np
+import pytest
+import shap
+
+
+def test_explanation_hstack():
+    """Checks that `hstack` works as expected with two valid Explanation objects.
+    And that it returns an Explanation object.
+    """
+    # generate 2 Explanation objects for stacking
+    rs = np.random.RandomState(0)
+    base_vals = np.ones(20) * 0.123
+    exp1 = shap.Explanation(
+        values=rs.randn(20, 7),
+        base_values=base_vals,
+    )
+    exp2 = shap.Explanation(
+        values=rs.randn(20, 5),
+        base_values=base_vals,
+    )
+    new_exp = exp1.hstack(exp2)
+
+    assert isinstance(new_exp, shap.Explanation)
+    assert new_exp.values.shape == (20, 12)
+
+
+def test_explanation_hstack_errors():
+    """Checks that `hstack` throws errors on invalid input.
+    """
+    # generate 2 Explanation objects for stacking
+    rs = np.random.RandomState(1)
+    base_vals = np.ones(20) * 0.123
+    base_exp = shap.Explanation(
+        values=rs.randn(20, 5),
+        base_values=base_vals,
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match="Can't hstack explanations with different numbers of rows",
+    ):
+        exp2 = shap.Explanation(
+            values=rs.randn(7, 5),
+            base_values=np.ones(7),
+        )
+        _ = base_exp.hstack(exp2)
+
+    with pytest.raises(
+        AssertionError,
+        match="Can't hstack explanations with different base values",
+    ):
+        exp2 = shap.Explanation(
+            values=rs.randn(20, 5),
+            base_values=np.ones(20) * 0.987,
+        )
+        _ = base_exp.hstack(exp2)


### PR DESCRIPTION
Part of #54.

1. `Explanation.hstack` method was using a non-existent variable "axis" (probably copied from the other helper methods like `sum`). The implementation as it is didn't make any sense, so I modified it to what I think made the most sense, which is to hstack the inner arrays and return a new Explanation object.
2. Added tests for hstack only.