### PR TITLE
ci: only run tests when src code changes

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,6 +13,7 @@ on:
       - "tests/**"
       - ".github/workflows/run_tests.yml"
       - "setup.py"
+      - "test"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,6 +14,10 @@ on:
       - ".github/workflows/run_tests.yml"
       - "setup.py"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_tests:
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,9 +11,9 @@ on:
     paths:
       - "shap/**"
       - "tests/**"
+      - "data/**"
       - ".github/workflows/run_tests.yml"
       - "setup.py"
-      - "test"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,12 +1,18 @@
 name: tests
 
 on:
+  # only run tests and coverage when src code changes
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
+    paths:
+      - "shap/**"
+      - "tests/**"
+      - ".github/workflows/run_tests.yml"
+      - "setup.py"
 
 jobs:
   run_tests:


### PR DESCRIPTION
## Changes

Just a small optimization

- not to waste resources running tests in PR when no source code is changed. E.g. if `CHANGELOG.md` or the Jupyter notebooks are updated. I still propose to always run tests when pushing to `master`.
- Make concurrency cancel-in-progress, which is to cancel running jobs if another push to the same ref was made in the meantime. See an example with this PR, the previous workflow was automatically canceled when another push was made to the same `ci/specify-paths` branch.
  ![image](https://github.com/dsgibbons/shap/assets/30731072/3736efa3-c86d-48d2-9eaa-1052c6ceee4c)