### PR TITLE
chore: add installation instructions #78 #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This fork primarily adds bug fixes and deprecation updates, to ensure that `shap
 
 **New contributors are very welcome** so please feel free to get involved, for example by submitting PRs or opening issues!
 
-We are eager to build a broad pool of maintainers, to avoid having a single person responsible for the entire repostitory. This repo adopts a _liberal contribution governance model_, where project decisions are based on a consensus seeking process. For more information, see [here](https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951).
+We are eager to build a broad pool of maintainers, to avoid having a single person responsible for the entire repository. This repo adopts a _liberal contribution governance model_, where project decisions are based on a consensus seeking process. For more information, see [here](https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,19 @@ This fork primarily adds bug fixes and deprecation updates, to ensure that `shap
 
 We are eager to build a broad pool of maintainers, to avoid having a single person responsible for the entire repostitory. This repo adopts a _liberal contribution governance model_, where project decisions are based on a consensus seeking process. For more information, see [here](https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951).
 
+## Installation
+
+This fork is not yet available on PyPI or conda. Our current goal is to merge the changes from this repository back into [slundberg/shap](https://github.com/slundberg/shap). If you would like to use this fork, the currently supported installation method is:
+
+```pip install git+https://github.com/dsgibbons/shap.git```
+
+If we are unable to merge our changes back into [slundberg/shap](https://github.com/slundberg/shap), we will create our own release on PyPI.
+
 ## Documentation
 
 Read the documentation for this fork here: [https://shap-community.readthedocs.io/en/latest/](https://shap-community.readthedocs.io/en/latest/)
+
+> :warning: **Note**: From this point onward, README.md is copied from from [slundberg/shap](https://github.com/slundberg/shap). Assume that any links or installation instructions refer to the original project and not this fork.
 
 # SHAP
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We are eager to build a broad pool of maintainers, to avoid having a single pers
 
 ## Installation
 
-This fork is not yet available on PyPI or conda. Our current goal is to merge the changes from this repository back into [slundberg/shap](https://github.com/slundberg/shap). If you would like to use this fork, the currently supported installation method is:
+This fork is not yet available on PyPI or conda. Our goal is to merge the changes from this fork back into [slundberg/shap](https://github.com/slundberg/shap). If you would like to use this fork, the currently supported installation method is:
 
 ```pip install git+https://github.com/dsgibbons/shap.git```
 
@@ -29,7 +29,7 @@ Read the documentation for this fork here: [https://shap-community.readthedocs.i
 
 <br>
 
-> **Warning**: From this point onward, README.md is copied from from [slundberg/shap](https://github.com/slundberg/shap). Assume that any links or installation instructions refer to the original project and not this fork.
+> **Warning**: From this point onward, README.md is copied from [slundberg/shap](https://github.com/slundberg/shap). Assume that any links or installation instructions refer to the original project and not this fork.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ We are eager to build a broad pool of maintainers, to avoid having a single pers
 
 This fork is not yet available on PyPI or conda. Our goal is to merge the changes from this fork back into [slundberg/shap](https://github.com/slundberg/shap). If you would like to use this fork, the currently supported installation method is:
 
-```pip install git+https://github.com/dsgibbons/shap.git```
+```
+pip install git+https://github.com/dsgibbons/shap.git
+```
 
 If we are unable to merge our changes back into [slundberg/shap](https://github.com/slundberg/shap), we will create our own release on PyPI.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ If we are unable to merge our changes back into [slundberg/shap](https://github.
 
 Read the documentation for this fork here: [https://shap-community.readthedocs.io/en/latest/](https://shap-community.readthedocs.io/en/latest/)
 
-> :warning: **Note**: From this point onward, README.md is copied from from [slundberg/shap](https://github.com/slundberg/shap). Assume that any links or installation instructions refer to the original project and not this fork.
+<br>
+
+> **Warning**: From this point onward, README.md is copied from from [slundberg/shap](https://github.com/slundberg/shap). Assume that any links or installation instructions refer to the original project and not this fork.
+
+<br>
 
 # SHAP
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,37 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+SHAP Community Fork
+-------------------
+
+This repository is a fork of Scott Lundberg's popular `shap <https://github.com/slundberg/shap>`_ library. Unfortunately, the original SHAP repository is not currently maintained. This fork attempts to fix SHAP's current issues and merge old PRs.
+
+What has changed on this fork?
+==============================
+
+This fork primarily adds bug fixes and deprecation updates, to ensure that SHAP works with the latest versions of other libaries. 
+
+Contributing
+============
+
+**New contributors are very welcome** so please feel free to get involved, for example by submitting PRs or opening issues!
+
+We are eager to build a broad pool of maintainers, to avoid having a single person responsible for the entire repostitory. This repo adopts a *liberal contribution governance model*, where project decisions are based on a consensus seeking process. For more information, see `here <https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951>`_.
+
+Installation
+============
+
+This fork is not yet available on PyPI or conda. Our goal is to merge the changes from this fork back into `slundberg/shap <https://github.com/slundberg/shap>`_. If you would like to use this fork, the currently supported installation method is:
+
+.. code-block::
+
+   pip install git+https://github.com/dsgibbons/shap.git
+
+If we are unable to merge our changes back into `slundberg/shap <https://github.com/slundberg/shap>`_, we will create our own release on PyPI.
+
+.. warning::
+   From this point onward, the documentation is mostly copied from `slundberg/shap <https://github.com/slundberg/shap>`_. Assume that any links or installation instructions refer to the original project and not this fork.
+
 Welcome to the SHAP documentation
 ---------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Contributing
 
 **New contributors are very welcome** so please feel free to get involved, for example by submitting PRs or opening issues!
 
-We are eager to build a broad pool of maintainers, to avoid having a single person responsible for the entire repostitory. This repo adopts a *liberal contribution governance model*, where project decisions are based on a consensus seeking process. For more information, see `here <https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951>`_.
+We are eager to build a broad pool of maintainers, to avoid having a single person responsible for the entire repository. This repo adopts a *liberal contribution governance model*, where project decisions are based on a consensus seeking process. For more information, see `here <https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951>`_.
 
 Installation
 ============


### PR DESCRIPTION
Add installation instructions to `README.md` and clear up confusion around PyPI/conda. See #78 and #80.