### PR TITLE
chore: make convert_color ruff compliant and add test

### DIFF
--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -6,17 +6,16 @@ import matplotlib.pyplot as pl
 
 
 def convert_color(color):
-    try:
-        color = pl.get_cmap(color)
-    except Exception:
-        pass
-
     if color == "shap_red":
-        color = colors.red_rgb
-    elif color == "shap_blue":
-        color = colors.blue_rgb
+        return colors.red_rgb
+    if color == "shap_blue":
+        return colors.blue_rgb
 
-    return color
+    try:
+        return pl.get_cmap(color)
+    except ValueError:
+        return color
+
 
 def convert_ordering(ordering, shap_values):
     if issubclass(type(ordering), OpChain):

--- a/tests/plots/test_utils.py
+++ b/tests/plots/test_utils.py
@@ -6,7 +6,15 @@ from shap.plots import colors
 from shap.plots._utils import convert_color
 
 
-@pytest.mark.parametrize(("color", "expected_result"), [("shap_red", colors.red_rgb), ("shap_blue", colors.blue_rgb), ("null", "null"), ("jet", pl.get_cmap("jet"))])
+@pytest.mark.parametrize(
+    ("color", "expected_result"),
+    [
+        ("shap_red", colors.red_rgb),
+        ("shap_blue", colors.blue_rgb),
+        ("null", "null"),
+        ("jet", pl.get_cmap("jet")),
+    ],
+)
 def test_convert_color(color, expected_result):
     result = convert_color(color)
 

--- a/tests/plots/test_utils.py
+++ b/tests/plots/test_utils.py
@@ -1,0 +1,16 @@
+import matplotlib.pyplot as pl
+import numpy as np
+import pytest
+
+from shap.plots import colors
+from shap.plots._utils import convert_color
+
+
+@pytest.mark.parametrize(("color", "expected_result"), [("shap_red", colors.red_rgb), ("shap_blue", colors.blue_rgb), ("null", "null"), ("jet", pl.get_cmap("jet"))])
+def test_convert_color(color, expected_result):
+    result = convert_color(color)
+
+    if isinstance(result, np.ndarray):
+        assert np.allclose(result, expected_result)
+    else:
+        assert result == expected_result


### PR DESCRIPTION
Following on from #54, this PR provides fixes for future `ruff` rules BLE001 (blanket exception catching) and S110 (try-except-pass). This PR also provides a test case to illustrate the purpose of `convert_color`. This test is probably a bit redundant, but good for extending coverage at least.