### PR TITLE
Chore: fix test suite warnings by closing tensorflow session

### DIFF
--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -124,6 +124,7 @@ def test_tf_keras_mnist_cnn(): # pylint: disable=too-many-locals
     sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
     d = np.abs(sums - diff).sum()
     assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % d
+    InteractiveSession.close()
 
 
 def test_tf_keras_linear():

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -52,7 +52,7 @@ def test_tf_keras_mnist_cnn(): # pylint: disable=too-many-locals
 
     config = ConfigProto()
     config.gpu_options.allow_growth = True
-    InteractiveSession(config=config)
+    sess = InteractiveSession(config=config)
 
     tf.compat.v1.disable_eager_execution()
 
@@ -117,14 +117,13 @@ def test_tf_keras_mnist_cnn(): # pylint: disable=too-many-locals
     e = shap.DeepExplainer((model.layers[0].input, model.layers[-1].input), x_train[inds, :, :])
     shap_values = e.shap_values(x_test[:1])
 
-    sess = tf.compat.v1.keras.backend.get_session()
     diff = sess.run(model.layers[-1].input, feed_dict={model.layers[0].input: x_test[:1]}) - \
     sess.run(model.layers[-1].input, feed_dict={model.layers[0].input: x_train[inds, :, :]}).mean(0)
 
     sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
     d = np.abs(sums - diff).sum()
     assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % d
-    InteractiveSession.close()
+    sess.close()
 
 
 def test_tf_keras_linear():

--- a/tests/explainers/test_gradient.py
+++ b/tests/explainers/test_gradient.py
@@ -19,7 +19,7 @@ def test_tf_keras_mnist_cnn():
 
     config = ConfigProto()
     config.gpu_options.allow_growth = True
-    InteractiveSession(config=config)
+    sess = InteractiveSession(config=config)
 
     tf.compat.v1.disable_eager_execution()
 
@@ -87,14 +87,13 @@ def test_tf_keras_mnist_cnn():
     e = shap.GradientExplainer((model.layers[0].input, model.layers[-1].input), x_train[inds, :, :])
     shap_values = e.shap_values(x_test[:1], nsamples=2000)
 
-    sess = tf.compat.v1.keras.backend.get_session()
     diff = sess.run(model.layers[-1].input, feed_dict={model.layers[0].input: x_test[:1]}) - \
     sess.run(model.layers[-1].input, feed_dict={model.layers[0].input: x_train[inds, :, :]}).mean(0)
 
     sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
     d = np.abs(sums - diff).sum()
     assert d / (np.abs(diff).sum() + 0.01) < 0.1, "Sum of SHAP values does not match difference! %f" % (d / np.abs(diff).sum())
-    InteractiveSession.close()
+    sess.close()
 
 
 def test_pytorch_mnist_cnn():

--- a/tests/explainers/test_gradient.py
+++ b/tests/explainers/test_gradient.py
@@ -94,6 +94,7 @@ def test_tf_keras_mnist_cnn():
     sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
     d = np.abs(sums - diff).sum()
     assert d / (np.abs(diff).sum() + 0.01) < 0.1, "Sum of SHAP values does not match difference! %f" % (d / np.abs(diff).sum())
+    InteractiveSession.close()
 
 
 def test_pytorch_mnist_cnn():


### PR DESCRIPTION
Fixes some warnings in the test suite by ensuring the `InteractiveSession` is closed.

The test could be rewritted to use a regular `Session` and perhaps a `with` statement, but this is a minimal change to fix the warning.