### PR TITLE
Prepare for fork merge: revert changes specific to SHAP Community Fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed the unused `mimic.py` file and `MimicExplainer` code
   ([#53](https://github.com/dsgibbons/shap/pull/53)).
 
-## [0.41.0] - 2022-06-16 (parent repo)
+## [0.41.0] - 2022-06-16
 
-For details of previous changes, see the release page of the parent repository
+For details of previous changes, see the release page on GitHub
 [here](https://github.com/slundberg/shap/releases).

--- a/README.md
+++ b/README.md
@@ -1,51 +1,19 @@
-# SHAP Community Fork
 
-![example workflow](https://github.com/dsgibbons/shap/actions/workflows/run_tests.yml/badge.svg)
-[![Documentation Status](https://readthedocs.org/projects/shap-community/badge/?version=latest)](https://shap-community.readthedocs.io/en/latest/?badge=latest)
-
-This repository is a fork of Scott Lundberg's popular [shap](https://github.com/slundberg/shap) library. Unfortunately, the original shap repo is not currently maintained. This fork attempts to fix shap's current issues and merge old PRs. See the general discussion on the purpose of this repo [here](https://github.com/dsgibbons/shap/discussions/11).
-
-## What has changed on this fork?
-
-This fork primarily adds bug fixes and deprecation updates, to ensure that `shap` works with the latest versions of other libaries. Check out the [changelog](CHANGELOG.md) for full details of updates.
-
-## Contributing
-
-**New contributors are very welcome** so please feel free to get involved, for example by submitting PRs or opening issues!
-
-We are eager to build a broad pool of maintainers, to avoid having a single person responsible for the entire repository. This repo adopts a _liberal contribution governance model_, where project decisions are based on a consensus seeking process. For more information, see [here](https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951).
-
-## Installation
-
-This fork is not yet available on PyPI or conda. Our goal is to merge the changes from this fork back into [slundberg/shap](https://github.com/slundberg/shap). If you would like to use this fork, the currently supported installation method is:
-
-```
-pip install git+https://github.com/dsgibbons/shap.git
-```
-
-If we are unable to merge our changes back into [slundberg/shap](https://github.com/slundberg/shap), we will create our own release on PyPI.
-
-## Documentation
-
-Read the documentation for this fork here: [https://shap-community.readthedocs.io/en/latest/](https://shap-community.readthedocs.io/en/latest/)
-
-<br>
-
-> **Warning**: From this point onward, README.md is copied from [slundberg/shap](https://github.com/slundberg/shap). Assume that any links or installation instructions refer to the original project and not this fork.
-
-<br>
-
-# SHAP
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/slundberg/shap/master/docs/artwork/shap_header.svg" width="800" />
 </p>
 
 ---
+![example workflow](https://github.com/slundberg/shap/actions/workflows/run_tests.yml/badge.svg)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/slundberg/shap/master)
+[![Documentation Status](https://readthedocs.org/projects/shap/badge/?version=latest)](https://shap.readthedocs.io/en/latest/?badge=latest)
 
 **SHAP (SHapley Additive exPlanations)** is a game theoretic approach to explain the output of any machine learning model. It connects optimal credit allocation with local explanations using the classic Shapley values from game theory and their related extensions (see [papers](#citations) for details and citations).
 
 <!--**SHAP (SHapley Additive exPlanations)** is a unified approach to explain the output of any machine learning model. SHAP connects game theory with local explanations, uniting several previous methods [1-7] and representing the only possible consistent and locally accurate additive feature attribution method based on expectations (see our [papers](#citations) for details and citations).-->
+
+
 
 ## Install
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,37 +3,6 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-SHAP Community Fork
--------------------
-
-This repository is a fork of Scott Lundberg's popular `shap <https://github.com/slundberg/shap>`_ library. Unfortunately, the original SHAP repository is not currently maintained. This fork attempts to fix SHAP's current issues and merge old PRs.
-
-What has changed on this fork?
-==============================
-
-This fork primarily adds bug fixes and deprecation updates, to ensure that SHAP works with the latest versions of other libaries. 
-
-Contributing
-============
-
-**New contributors are very welcome** so please feel free to get involved, for example by submitting PRs or opening issues!
-
-We are eager to build a broad pool of maintainers, to avoid having a single person responsible for the entire repository. This repo adopts a *liberal contribution governance model*, where project decisions are based on a consensus seeking process. For more information, see `here <https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951>`_.
-
-Installation
-============
-
-This fork is not yet available on PyPI or conda. Our goal is to merge the changes from this fork back into `slundberg/shap <https://github.com/slundberg/shap>`_. If you would like to use this fork, the currently supported installation method is:
-
-.. code-block::
-
-   pip install git+https://github.com/dsgibbons/shap.git
-
-If we are unable to merge our changes back into `slundberg/shap <https://github.com/slundberg/shap>`_, we will create our own release on PyPI.
-
-.. warning::
-   From this point onward, the documentation is mostly copied from `slundberg/shap <https://github.com/slundberg/shap>`_. Assume that any links or installation instructions refer to the original project and not this fork.
-
 Welcome to the SHAP documentation
 ---------------------------------
 


### PR DESCRIPTION
This branch aims to get this fork ready for merging into the main repo, by reverting any fork-specific changes such as the change to the README. I will continually rebase this branch on top of `dsgibbons/master`.

Pending ongoing discussion on https://github.com/slundberg/shap/discussions/2942