### PR TITLE
Fix failing C++ CodeQL checks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'python' ]
+        language: [ 'cpp', 'javascript', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
@@ -61,8 +61,13 @@ jobs:
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    # - name: Autobuild
+    #   uses: github/codeql-action/autobuild@v2
+
+    - name: Build python package
+      run: |
+        pip install build
+        python -m build
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,8 +5,6 @@
 # or to provide custom queries or build logic.
 #
 
-# Nb. template has been edited to specify the desired list of languages.
-
 name: "CodeQL"
 
 on:
@@ -17,12 +15,15 @@ on:
     branches: [ "master" ]
     paths:
       - "shap/**"
-      - "javascripts/**"
+      - "javascript/**"
       - "tests/**"
       - "data/**"
       - ".github/workflows/codeql-analysis.yml"
       - "**.py"
       - "**.js"
+      - "**.cc"
+      - "**.cu"
+      - "**.h"
   schedule:
     - cron: '16 9 * * 1'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,11 +4,9 @@
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
 #
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
+
+# Nb. template has been edited to specify the desired list of languages.
+
 name: "CodeQL"
 
 on:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'javascript', 'python' ]
+        language: [ 'javascript', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
@@ -70,3 +70,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,14 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
+    paths:
+      - "shap/**"
+      - "javascripts/**"
+      - "tests/**"
+      - "data/**"
+      - ".github/workflows/codeql-analysis.yml"
+      - "**.py"
+      - "**.js"
   schedule:
     - cron: '16 9 * * 1'
 


### PR DESCRIPTION
This PR aims to get the CodeQL check running and passing. The upstream slundberg repo has CodeQL scanning enabled, and the CPP check currently fails. 

EDIT: updated to fix build dependency, and keep `cpp` check.