### PR TITLE
Add `__call__` method to `KernelExplainer`

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -17,6 +17,12 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from tqdm.auto import tqdm
 from ._explainer import Explainer
+from .._explanation import Explanation
+import time
+
+# Suppress the sklearn warning
+# 'UserWarning: X does not have valid feature names, but <model> was fitted with feature names'
+warnings.filterwarnings('ignore', module='sklearn')
 
 log = logging.getLogger('shap')
 
@@ -62,7 +68,12 @@ class Kernel(Explainer):
     See :ref:`Kernel Explainer Examples <kernel_explainer_examples>`
     """
 
-    def __init__(self, model, data, link=IdentityLink(), **kwargs):
+    def __init__(self, model, data, feature_names=None, link=IdentityLink(), **kwargs):
+
+        if feature_names is not None:
+            self.data_feature_names=feature_names
+        elif safe_isinstance(data, "pandas.core.frame.DataFrame"):
+            self.data_feature_names = list(data.columns)
 
         # convert incoming inputs to standardized iml objects
         self.link = convert_to_link(link)
@@ -108,6 +119,27 @@ class Kernel(Explainer):
         else:
             self.D = self.fnull.shape[0]
 
+    def __call__(self, X):
+
+        start_time = time.time()
+
+        if safe_isinstance(X, "pandas.core.frame.DataFrame"):
+            feature_names = list(X.columns)
+            X = X.values
+        else:
+            feature_names = getattr(self, "data_feature_names", None)
+       
+        v = self.shap_values(X)
+        if type(v) is list:
+            v = np.stack(v, axis=-1) # put outputs at the end
+        
+        # the explanation object expects an expected value for each row
+        if hasattr(self.expected_value, "__len__"):
+            ev_tiled = np.tile(self.expected_value, (v.shape[0],1))
+        else:
+            ev_tiled = np.tile(self.expected_value, v.shape[0])
+
+        return Explanation(v, base_values=ev_tiled, data=X, feature_names=feature_names, compute_time=time.time() - start_time)
 
     def shap_values(self, X, **kwargs):
         """ Estimate the SHAP values for a set of samples.


### PR DESCRIPTION
Currently the `KernelExplainer` class inherits its `__call__` method from the superclass `Explainer`. This is a problem for `KernelExplainer` because it does not have a `masker` attribute, e.g. [this SO question](https://stackoverflow.com/questions/75137492/attributeerror-kernel-object-has-no-attribute-masker-during-training-of-svc). I based the new `__call__` method on that of the `TreeExplainer`.